### PR TITLE
Pin nixpkgs

### DIFF
--- a/PyF.cabal
+++ b/PyF.cabal
@@ -19,12 +19,12 @@ library
                   PyF.Formatters
 
   build-depends:       base >= 4.9 && < 5.0
-                     , template-haskell >= 2.11 && < 2.14
+                     , template-haskell >= 2.11 && < 2.15
 
                      -- Parsec and some transitive deps
                      , megaparsec >= 6.0 && < 6.6
                      , text >= 0.11 && < 1.3
-                     , containers >= 0.5 && < 0.6
+                     , containers >= 0.5 && < 0.7
 
                      --
                      , haskell-src-meta

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,18 @@
-with import <nixpkgs> {};
+{ nixpkgs ? ./nixpkgs.nix }:
+with import nixpkgs {};
 haskellPackages.developPackage {
-  root = ./.;
+  name = "PyF";
+
+  # Filter temp files, git files, .ghc.environment and .nix files
+  # which are not part of the build
+  root = lib.sources.cleanSourceWith {
+    filter = name: type: let baseName = baseNameOf (toString name); in
+    !(lib.hasPrefix ".ghc.environment." baseName) && (baseName != "default.nix");
+    src = lib.sources.cleanSource ./.;
+  };
+
+  overrides = self: super: {
+    # PyF is not compatible yet with megaparsec 7
+    megaparsec = super.megaparsec_6_5_0;
+  };
 }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,5 @@
+import (fetchTarball {
+   # 25/01/2019
+   url = https://github.com/nixos/nixpkgs/archive/11cf7d6e1ff.tar.gz;
+   sha256 = "0zcg4mgfdk3ryiqj1j5iv5bljjvsgi6q6j9z1vkq383c4g4clc72";
+})


### PR DESCRIPTION
- nixpkgs.nix file stores the current nixpkgs version
- add a source filter to ensure that changes to not used files (such
  as .nix) does not trigger a rebuild
- Which can be override using --arg nixpkgs "<nixpkgs>" when calling nix-shell
- We pin megaparsec to previous version