### PR TITLE
Allows PyF to be extended with new types.

### DIFF
--- a/.golden/-7029437438637288708/golden
+++ b/.golden/-7029437438637288708/golden
@@ -1,0 +1,9 @@
+
+INITIALPATH:7:20: error:
+    • No instance for (RealFloat Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)
+  |
+7 | main = putStrLn [f|{True:f}|]
+  |                    ^^^^^^^^^^

--- a/.golden/-7030000414293697510/golden
+++ b/.golden/-7030000414293697510/golden
@@ -1,0 +1,9 @@
+
+INITIALPATH:7:20: error:
+    • No instance for (Integral Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)
+  |
+7 | main = putStrLn [f|{True:d}|]
+  |                    ^^^^^^^^^^

--- a/.golden/-7033096789363194467/golden
+++ b/.golden/-7033096789363194467/golden
@@ -1,0 +1,9 @@
+
+INITIALPATH:7:20: error:
+    • No instance for (PyFToString Bool) arising from a use of ‘toString’
+    • In the second argument of ‘(.)’, namely ‘toString’
+      In the expression: (PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString
+      In the first argument of ‘putStrLn’, namely ‘(((PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString) True)’
+  |
+7 | main = putStrLn [f|{True:s}|]
+  |                    ^^^^^^^^^^

--- a/.golden/-8866962460351694124/golden
+++ b/.golden/-8866962460351694124/golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:20: error:
-    • No instance for (PyF.Internal.QQ.Stringable Float) arising from a use of ‘PyF.Internal.QQ.toString’
-    • In the second argument of ‘(.)’, namely ‘PyF.Internal.QQ.toString’
-      In the expression: (PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . PyF.Internal.QQ.toString
-      In the first argument of ‘putStrLn’, namely ‘(((PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . PyF.Internal.QQ.toString) number)’
+    • No instance for (PyFToString Float) arising from a use of ‘toString’
+    • In the second argument of ‘(.)’, namely ‘toString’
+      In the expression: (PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString
+      In the first argument of ‘putStrLn’, namely ‘(((PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString) number)’
   |
 7 | main = putStrLn [f|{number:s}|]
   |                    ^^^^^^^^^^^^

--- a/.golden/1640634027373935614/golden
+++ b/.golden/1640634027373935614/golden
@@ -1,0 +1,9 @@
+
+INITIALPATH:7:20: error:
+    • No instance for (PyF.Internal.QQ.FormatAny2 (PyFClassify Bool) Bool 'PyF.Formatters.AlignAll) arising from a use of ‘PyF.Internal.QQ.formatAny’
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)
+  |
+7 | main = putStrLn [f|{True}|]
+  |                    ^^^^^^^^

--- a/.golden/5755283065522441917/golden
+++ b/.golden/5755283065522441917/golden
@@ -1,15 +1,15 @@
 
 INITIALPATH:7:20: error:
-    • Ambiguous type variable ‘t0’ arising from a use of ‘PyF.Internal.QQ.toString’
-      prevents the constraint ‘(PyF.Internal.QQ.Stringable t0)’ from being solved.
+    • Ambiguous type variable ‘t0’ arising from a use of ‘toString’
+      prevents the constraint ‘(PyFToString t0)’ from being solved.
       Probable fix: use a type annotation to specify what ‘t0’ should be.
       These potential instances exist:
-        instance PyF.Internal.QQ.Stringable String -- Defined in ‘PyF.Internal.QQ’
+        instance [safe] PyFToString String -- Defined in ‘PyF.Class’
         ...plus two instances involving out-of-scope types
         (use -fprint-potential-instances to see them all)
-    • In the second argument of ‘(.)’, namely ‘PyF.Internal.QQ.toString’
-      In the expression: (PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . PyF.Internal.QQ.toString
-      In the first argument of ‘putStrLn’, namely ‘(((PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . PyF.Internal.QQ.toString) (truncate number))’
+    • In the second argument of ‘(.)’, namely ‘toString’
+      In the expression: (PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString
+      In the first argument of ‘putStrLn’, namely ‘(((PyF.Formatters.formatString (PyF.Internal.QQ.newPaddingKForString PyF.Internal.QQ.PaddingDefaultK)) Nothing . toString) (truncate number))’
   |
 7 | main = putStrLn [f|{truncate number:s}|]
   |                    ^^^^^^^^^^^^^^^^^^^^^

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # Revision history for PyF
 
+- PyF now exposes the typeclass `PyFToString` and `PyFClassify` which can be extended to support any type as input for the formatters.
 - PyF now uses `Data.String.IsString t` as its output type. It means that it behaves as a string literal as if the `OverloadedStrings` was enabled. This also works that PyF can outputs any standard string.
 - A caveat of the previous change is that PyF does not have instances for `IO` anymore.
 

--- a/PyF.cabal
+++ b/PyF.cabal
@@ -14,6 +14,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:
                   PyF
+                  PyF.Class
                   PyF.Internal.PythonSyntax
                   PyF.Internal.QQ
                   PyF.Internal.Extensions

--- a/Readme.md
+++ b/Readme.md
@@ -150,6 +150,18 @@ For example:
 "hello 3.14"
 ```
 
+# Custom types
+
+PyF can format three categories of input types:
+
+- Floating. Using the `f`, `g`, `e`, ... type specifiers. Any type instance of `RealFloat` can be formated as such.
+- Integral. Using the `d`, `b`, `x`, `o`, ... type specifiers. Any type instance of `Integral` can be formated as such.
+- String. Using the `s` type specifier. Any type instance of `PyFToString` can be formated as such.
+
+See `PyF.Class` if you want to create new instances for the `PyFToString` class.
+
+By default, if you do not provide any type specifier, PyF uses the `PyFClassify` type class to decide if your type must be formated as a Floating, Integral or String.
+
 # Caveats
 
 ## Type inference
@@ -259,7 +271,7 @@ The implementation is unit-tested against the reference python implementation (p
 
 - Number `n` formatter is not supported. In python this formatter can format a number and use current locale information for decimal part and thousand separator. There is no plan to support that because of the impure interface needed to read the locale.
 - Python support sub variables in the formatting options, such as `{varname:.{precision}}`, we should too. However should we accept `String` parameter (such as `<`), with a possible runtime error, or should we use the `ADT` such as `AlignRight`?
-- Python literal integers accepts binary/octal/hexa/decimal literals, PyF only accept decimal ones, hdece in to plan to support that, if you really need to format a float with a number of digit provided as a binary constant, open an issue.
+- Python literal integers accepts binary/octal/hexa/decimal literals, PyF only accept decimal ones, I don't have a plan to support that, if you really need to format a float with a number of digit provided as a binary constant, open an issue.
 - Python support adding custom formatters for new types, such as date. This may be really cool, for example `[f|{today:%Y-%M-%D}`. I don't know how to support that now.
 
 ### Difference
@@ -277,15 +289,6 @@ nix-shell # Optional, if you use nix
 cabal new-build
 cabal new-test
 ```
-
-# TODO
-
-- Improve the error reporting with more Parsec annotation
-- Improve the parser for sub-expression (handle the `:` and `}` cases if possible).
-- Allow extension to others type / custom formatters (for date for example)
-- Improve code quality. This code is really ugly, but there is a really strong test suite so, well.
-- Work on performance, do we really care? For now, everything is internally done with `String`.
-- Directly expose the formatter to be used as a template haskell splice
 
 # Library note
 

--- a/src/PyF.hs
+++ b/src/PyF.hs
@@ -7,15 +7,17 @@ module PyF
   ( f
    -- * With custom delimiters
   , fWithDelimiters
+  , module PyF.Class
   )
 where
 
 import           Language.Haskell.TH.Quote (QuasiQuoter(..))
-import qualified PyF.Internal.QQ as QQ
+import PyF.Internal.QQ (toExp)
+import PyF.Class
 
 templateF :: (Char, Char) -> String -> QuasiQuoter
 templateF delimiters fName = QuasiQuoter {
-    quoteExp = \s -> (QQ.toExp delimiters s)
+    quoteExp = \s -> (toExp delimiters s)
   , quotePat = err "pattern"
   , quoteType = err "type"
   , quoteDec = err "declaration"

--- a/src/PyF/Class.hs
+++ b/src/PyF/Class.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
+module PyF.Class where
+
+import Data.Int
+import Data.Word
+import Numeric.Natural
+
+import qualified Data.Text.Lazy as LText
+import qualified Data.Text as SText
+
+-- | The three categories of formatting in 'PyF'
+data PyFCategory
+  = PyFIntegral
+  -- ^ Format as an integral, no fractional part, precise value
+  | PyFFractional
+  -- ^ Format as a fractional, approximate value with a fractional part
+  | PyFString
+  -- ^ Format as a string
+
+-- | Classify a type to a 'PyFCategory'
+--   This classification will be used to decide which formatting to
+--   use when no type specifier in provided.
+type family PyFClassify t :: PyFCategory
+
+type instance PyFClassify Integer = 'PyFIntegral
+type instance PyFClassify Int = 'PyFIntegral
+type instance PyFClassify Int8 = 'PyFIntegral
+type instance PyFClassify Int16 = 'PyFIntegral
+type instance PyFClassify Int32 = 'PyFIntegral
+type instance PyFClassify Int64 = 'PyFIntegral
+type instance PyFClassify Natural = 'PyFIntegral
+type instance PyFClassify Word = 'PyFIntegral
+type instance PyFClassify Word8 = 'PyFIntegral
+type instance PyFClassify Word16 = 'PyFIntegral
+type instance PyFClassify Word32 = 'PyFIntegral
+type instance PyFClassify Word64 = 'PyFIntegral
+
+type instance PyFClassify Float = 'PyFFractional
+type instance PyFClassify Double = 'PyFFractional
+
+type instance PyFClassify String = 'PyFString
+type instance PyFClassify LText.Text = 'PyFString
+type instance PyFClassify SText.Text = 'PyFString
+
+-- | Convert a type to string
+--   The default implementation uses `Show`
+class PyFToString t where
+  toString :: t -> String
+  default toString :: Show t => t -> String
+  toString = show
+
+instance PyFToString String where toString = id
+instance PyFToString LText.Text where toString = LText.unpack
+instance PyFToString SText.Text where toString = SText.unpack

--- a/test/SpecFail.hs
+++ b/test/SpecFail.hs
@@ -212,3 +212,9 @@ spec = do
       mapM_ fileFailCompile [
         "test/failureCases/bug18.hs"
         ]
+
+    describe "Wrong type" $ do
+      failCompile "{True:s}"
+      failCompile "{True}"
+      failCompile "{True:f}"
+      failCompile "{True:d}"


### PR DESCRIPTION
Two typeclasses are now exposed:

- `PyFClassify` which select the default formatting mode for you type
- `PyToString` which allows a type to be formatted as a string

Any instance of `PyFToString`, `RealFloat` or `Integral` can be
formatted with `PyF`.

Closes #21 