### PR TITLE
Remove splice of `fromInteger` in TH

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # Revision history for PyF
 
+- PyF now longer emit unnecessary default typing.
 - PyF now exposes the typeclass `PyFToString` and `PyFClassify` which can be extended to support any type as input for the formatters.
-- PyF now uses `Data.String.IsString t` as its output type. It means that it behaves as a string literal as if the `OverloadedStrings` was enabled. This also works that PyF can outputs any standard string.
+- PyF now uses `Data.String.IsString t` as its output type. It means that it behaves as a string literal as if the `OverloadedStrings` was enabled. This also means that PyF can outputs any standard string.
 - A caveat of the previous change is that PyF does not have instances for `IO` anymore.
 
 ### bugfixes and general improvements

--- a/src/PyF/Internal/QQ.hs
+++ b/src/PyF/Internal/QQ.hs
@@ -116,11 +116,11 @@ toFormat _ (Replacement expr y) = do
 
 changePrec :: Precision -> Q Exp
 changePrec PrecisionDefault = [| Just 6 |]
-changePrec (Precision n) = [| Just (fromIntegral n) |]
+changePrec (Precision n) = [| Just n |]
 
 changePrec' :: Precision ->  Q Exp
 changePrec' PrecisionDefault = [| Nothing |]
-changePrec' (Precision n) = [| Just (fromIntegral n) |]
+changePrec' (Precision n) = [| Just n |]
 
 toGrp :: Maybe Char -> Int -> Q Exp
 toGrp mb a = [| grp |]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS -Wno-type-defaults #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ExtendedDefaultRules #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -261,7 +259,7 @@ yeah\
     it "Text" $ do
       ([f|\
 {pi:.0}
-|] :: Text) `shouldBe` "3\n"
+|] :: Text) `shouldBe` (pack "3\n")
     it "String" $ do
       ([f|\
 {pi:.0}


### PR DESCRIPTION
They were useless and were triggering a default type selection and associated warnings.