### PR TITLE
Polymorphism is now less magic

### DIFF
--- a/.golden/2897849520519503487/golden
+++ b/.golden/2897849520519503487/golden
@@ -1,10 +1,10 @@
 
 INITIALPATH:26:3: error: [-Wmissing-fields, -Werror=missing-fields]
     • Fields of ‘Foo’ not initialised: fieldA
-    • In the expression: Foo {fieldB = (("hello what's up " <> ((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) x))}
+    • In the expression: Foo {fieldB = (Data.String.fromString ("hello what's up " <> ((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) x))}
       In an equation for ‘yolo’:
           yolo
-            = Foo {fieldB = (("hello what's up " <> ((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) x))}
+            = Foo {fieldB = (Data.String.fromString ("hello what's up " <> ((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) x))}
             where
                 x :: T.Text
                 x = T.pack "hi"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 - PyF now longer emit unnecessary default typing.
 - PyF now exposes the typeclass `PyFToString` and `PyFClassify` which can be extended to support any type as input for the formatters.
-- PyF now uses `Data.String.IsString t` as its output type. It means that it behaves as a string literal as if the `OverloadedStrings` was enabled. This also means that PyF can outputs any standard string.
+- PyF now uses `Data.String.IsString t` as its output type if `OverloadedString` is enabled. It means that it behaves as a real haskell string literal.
 - A caveat of the previous change is that PyF does not have instances for `IO` anymore.
 
 ### bugfixes and general improvements

--- a/PyF.cabal
+++ b/PyF.cabal
@@ -46,6 +46,14 @@ test-suite pyf-test
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+test-suite pyf-overloaded
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             SpecOverloaded.hs
+  build-depends:       base, PyF, hspec, text, bytestring
+  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
 test-suite pyf-failure
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test

--- a/Readme.md
+++ b/Readme.md
@@ -141,9 +141,7 @@ Will returns `-a\n-b`. Note how the first and last line breaks are ignored.
 
 # Output type
 
-*PyF* main entry point `f` is polymorphic and can represents any type of string, it uses the [`IsString`](http://hackage.haskell.org/package/base/docs/Data-String.html#t:IsString) interface. Most of the time, type inference will do the right thing for you, but you may need to add type annotations.
-
-For example:
+*PyF* aims at extending the string literal syntax. As such, it default to `String` type. However, if the `OverloadedString` is enabled, PyF will happilly generate `IsString t => t` instead. This means that you can use PyF to generate `String`, but also `Text` and why not `ByteString`, with all the caveats known to this extension.
 
 ```haskell
 >>> [f|hello {pi.2}|] :: String

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -256,10 +256,6 @@ yeah\
 |] `shouldBe` "\\\n- a\n- b\n"
 
   describe "empty trailing value" $ do
-    it "Text" $ do
-      ([f|\
-{pi:.0}
-|] :: Text) `shouldBe` (pack "3\n")
     it "String" $ do
       ([f|\
 {pi:.0}

--- a/test/SpecOverloaded.hs
+++ b/test/SpecOverloaded.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+import Test.Hspec
+
+import PyF
+import Data.Text
+import Data.ByteString
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Test formatting with different types" $ do
+    it "String" $ do
+      [f|hello {10:d}|] `shouldBe` ("hello 10" :: String)
+    it "Text" $ do
+      [f|hello {10:d}|] `shouldBe` ("hello 10" :: Text)
+    it "ByteString" $ do
+      [f|hello {10:d}|] `shouldBe` ("hello 10" :: ByteString)


### PR DESCRIPTION
- `fmt` generates `String` if `OverloadedString` is not enabled.
- `fmt` generate `IsString t` if `OverloadedString` is enabled. `fmt`
  was used to generate `IsString t, Monoid t` before, this is now fixed.