### PR TITLE
Stack CI update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,19 @@ jobs:
     working_directory: ~/PyF
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - cci-nix-{{ checksum "nixpkgs.nix" }}-{{ checksum "default.nix" }}-{{ checksum "PyF.cabal" }}
+            - cci-nix-{{ checksum "nixpkgs.nix" }}-{{ checksum "default.nix" }}
+            - cci-nix-{{ checksum "nixpkgs.nix" }}
+      - run:
+          name: Prefetch
+          command: nix-shell --command true
+      - save_cache:
+          name: Cache Dependencies
+          key: cci-nix-{{ checksum "nixpkgs.nix" }}-{{ checksum "default.nix" }}-{{ checksum "PyF.cabal" }}
+          paths:
+            - "/nix/store"
       - run:
           name: Build
           command: nix-build -A pyf-sdist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,52 @@
 version: 2
 
 jobs:
-  build:
+  nix:
     docker:
       - image: nixos/nix:latest
     working_directory: ~/PyF
     steps:
       - checkout
       - run:
-          name: Build (Cabal+nix)
+          name: Build
           command: nix-build -A pyf-sdist
+
+  stack:
+    docker:
+      - image: fpco/stack-build:lts
+    working_directory: ~/PyF
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "PyF.cabal" }}
+            - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}
       - run:
-          name: Build (Stack+nix)
-          command: nix-shell -p stack --run 'stack test'
+          # see: https://github.com/commercialhaskell/stackage/issues/4783
+          # `ghc-lib-parser` conflicts with `template-haskell` for module Language.Haskell.TH.Syntax
+          # The test suite uses a bare GHC (with all the provided
+          # packages). This is fine in nix, but does not work in the
+          # stackage CI context where GHC comes with a world of
+          # packages.
+          # This is here to ensure that it will continue to work in stack CI.
+          name: Trash the environment
+          command: stack install ghc-lib-parser
+      - run:
+          name: Build dependencies
+          command: stack test --only-dependencies
+      - save_cache:
+          name: Cache Dependencies
+          key: cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "PyF.cabal" }}
+          paths:
+            - "/root/.stack"
+            - ".stack-work"
+      - run:
+          name: Build
+          command: stack test
+
+workflows:
+  version: 2
+  nix_stack:
+    jobs:
+      - nix
+      - stack

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,6 @@ packages:
 - .
 
 nix:
-  enable: true
+  # Not enabled by default. It will be on nixos, but not on CI
+  enable: false
   packages: [ python3 ]

--- a/test/SpecFail.hs
+++ b/test/SpecFail.hs
@@ -49,7 +49,17 @@ checkCompile content = withSystemTempFile "PyFTest.hs" $ \path fd -> do
                                                             -- Tests use a filename in a temporary directory which may have a long filename which triggers
                                                             -- line wrapping, reducing the reproducibility of error message
                                                             -- By setting the column size to a high value, we ensure reproducible error messages
-                                                             "-dppr-cols=10000000000000"
+                                                             "-dppr-cols=10000000000000",
+                                                            -- Clean package environment
+                                                            "-hide-all-packages",
+                                                            "-package base",
+                                                            "-package megaparsec",
+                                                            "-package text",
+                                                            "-package template-haskell",
+                                                            "-package haskell-src-exts",
+                                                            "-package haskell-src-meta",
+                                                            "-package mtl",
+                                                            "-package containers"
                                                             ] ""
   case ecode of
     ExitFailure _ -> pure (CompileError (sanitize path stderr))
@@ -67,7 +77,7 @@ sanitize path s =
   -- strip the filename
   let
     t = Text.pack s
-  in Text.unpack (Text.replace (Text.pack path) (Text.pack "INITIALPATH") t) 
+  in Text.unpack (Text.replace (Text.pack path) (Text.pack "INITIALPATH") t)
 
 golden :: HasCallStack => String -> String -> IO ()
 golden name output = do


### PR DESCRIPTION
- Use a custom job in CI
- Disable nix
- Trash the environment with a conflicting package. `ghc-lib-parser`
  conflicts with `template-haskell`.