### PR TITLE
Syb instead of uniplate

### DIFF
--- a/PyF.cabal
+++ b/PyF.cabal
@@ -37,7 +37,7 @@ library
                      , mtl
                      , ghc
                      , ghc-boot
-                     , uniplate
+                     , syb
   hs-source-dirs: src
   ghc-options: -Wall -Wunused-packages
   default-language:    Haskell2010

--- a/src/PyF/Internal/ParserEx.hs
+++ b/src/PyF/Internal/ParserEx.hs
@@ -7,6 +7,9 @@
 
 -- Note: This code was mostly copied from:
 -- https://github.com/shayne-fletcher/ghc-lib-parser-ex
+-- Changes done:
+--   - integration of the ghc version .h file in top of the file
+--   - switch from uniplate to syb in order to reduce dependencies footprint.
 
 module PyF.Internal.ParserEx (fakeSettings, fakeLlvmConfig, parseExpression, applyFixities, preludeFixities,baseFixities)
 where
@@ -95,8 +98,8 @@ import BasicTypes
 import OccName
 #endif
 
-import Data.Generics.Uniplate.Data
 import Data.Maybe
+import Data.Generics (everywhere, mkT)
 
 fakeSettings :: Settings
 fakeSettings = Settings
@@ -207,8 +210,8 @@ parseExpression = parse Parser.parseExpression
 -- | Rearrange a parse tree to account for fixities.
 applyFixities :: Data a => [(String, Fixity)] -> a -> a
 applyFixities fixities m =
-  let m'  = transformBi (expFix fixities) m
-      m'' = transformBi (patFix fixities) m'
+  let m'  = everywhere (mkT $ expFix fixities) m
+      m'' = everywhere (mkT $ patFix fixities) m'
   in m''
 
 preludeFixities :: [(String, Fixity)]

--- a/test/SpecFail.hs
+++ b/test/SpecFail.hs
@@ -55,7 +55,7 @@ checkCompile content = withSystemTempFile "PyFTest.hs" $ \path fd -> do
         "-package text",
         "-package template-haskell",
         "-package ghc-boot",
-        "-package uniplate",
+        "-package syb",
         "-package mtl",
         "-package ghc",
         "-package containers"


### PR DESCRIPTION
This reduces the build time of dependencies (from 39s to
32s).