### PR TITLE
Support for ByteString and Real

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,12 @@
 
 - Remove the dependency to `megaparsec` and replaces it by `parsec`. This should have minor impact on the error messages, however it reduces the dependencies size, because `parsec` is part of the standard `ghc` distribution.
 - *Huge Change*. The parsing of embeded expression does not depend anymore on `haskell-src-ext` and `haskell-src-meta` and instead depends on the built-in `ghc` lib. The direct result is that `PyF` have fewer dependencies. A `stack` build from scratch now takes 35s versus 4 minutes and 20s before.
+- Added instances for `(Lazy)ByteString` to `PyFClassify` and `PyFToString`. `ByteString` can now be integrated into format string, and will be decoded as ascii.
+- Relax the constraint for floating point formatting from `RealFrac` to `Real`. As a result, a few new type can be formatted as floating point number. One drawback is that some `Integral` are `Real` too and hence it is not an error anymore to format an integral as floating point, but you still need to explicitly select a floating point formatter.
+- Added instance for `(Nominal)DiffTime` to `PyFClassify`, so you can now format them without conversion.
+- Introducing of the new typeclass `PyfFormatIntegral` and `PyfFormatFractional` in order to customize the formatting for numbers. An instance is derived for respectively any `Integral` and `Real` types.
+- Support for `Char` formatting, as string (showing the `Char` value) or as integral, showing the `ord`.
+- `Data.Ratio`.
 
 ## 0.9.0.3 -- 2021-02-06
 

--- a/PyF.cabal
+++ b/PyF.cabal
@@ -31,6 +31,7 @@ library
                      , bytestring
                      , template-haskell
                      , text
+                     , time
 
                      , parsec
                      , mtl
@@ -40,13 +41,14 @@ library
   hs-source-dirs: src
   ghc-options: -Wall -Wunused-packages
   default-language:    Haskell2010
+  default-extensions: QuasiQuotes
 
 test-suite pyf-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
   other-modules: SpecUtils SpecCustomDelimiters
-  build-depends:       base, PyF, hspec, template-haskell
+  build-depends:       base, PyF, hspec, template-haskell, text, bytestring, time
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N -Wunused-packages
   default-language:    Haskell2010
   if flag(python_test)

--- a/src/PyF.hs
+++ b/src/PyF.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleInstances, BangPatterns #-}
 
 -- | A lot of quasiquoters to format and interpolate string expression
 module PyF

--- a/src/PyF/Class.hs
+++ b/src/PyF/Class.hs
@@ -1,16 +1,56 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+-- | You want to add formatting support for your custom type. This is the right module.
+--
+-- In PyF, formatters are in three categories:
+--
+-- - Integral numbers, which are numbers without fractional part
+-- - Fractional numbers, which are numbers with a fractional part
+-- - String, which represents text.
+--
+-- The formatting can be either explicit or implicit. For example:
+--
+-- >>> let x = 10 in [fmt|{x}|]
+-- 10
+--
+-- Is an implicit formating to number, but:
+--
+-- >>> let x = 10 in [fmt|{x:d}|]
+--
+-- Is an explicit formatting to Integral numbers, using @d@.
+--
+-- Implicit formatting will only format to either Integral, Fractional or text,
+-- and this choice is done by the (open) type family `PyFCategory'.
+--
+-- This modules also provides 3 type class for formatting.
+--
+-- - 'PyfFormatFractional' and 'PyfFormatIntegral' are responsible for
+-- formatting integral and fractional numbers. Default instances are provided
+-- respectively for 'Real' and 'Integral'. 'PyFToString' is in charge of
+-- formatting text.
 module PyF.Class where
 
+import qualified Data.ByteString
+import qualified Data.ByteString.Lazy
+import Data.Char (ord)
 import Data.Int
+import qualified Data.Ratio
 import qualified Data.Text as SText
+import qualified Data.Text.Encoding as E
 import qualified Data.Text.Lazy as LText
+import qualified Data.Time
 import Data.Word
 import Numeric.Natural
+import PyF.Formatters
+
+-- * Default formatting classification
 
 -- | The three categories of formatting in 'PyF'
 data PyFCategory
@@ -50,9 +90,19 @@ type instance PyFClassify Word32 = 'PyFIntegral
 
 type instance PyFClassify Word64 = 'PyFIntegral
 
+-- Float numbers
+
 type instance PyFClassify Float = 'PyFFractional
 
 type instance PyFClassify Double = 'PyFFractional
+
+type instance PyFClassify Data.Time.DiffTime = 'PyFFractional
+
+type instance PyFClassify Data.Time.NominalDiffTime = 'PyFFractional
+
+type instance PyFClassify (Data.Ratio.Ratio i) = 'PyFFractional
+
+-- String
 
 type instance PyFClassify String = 'PyFString
 
@@ -60,12 +110,18 @@ type instance PyFClassify LText.Text = 'PyFString
 
 type instance PyFClassify SText.Text = 'PyFString
 
+type instance PyFClassify Data.ByteString.ByteString = 'PyFString
+
+type instance PyFClassify Data.ByteString.Lazy.ByteString = 'PyFString
+
+type instance PyFClassify Char = 'PyFString
+
+-- * String formatting
+
 -- | Convert a type to string
---   The default implementation uses `Show`
+-- This is used for the string formatting.
 class PyFToString t where
   pyfToString :: t -> String
-  default pyfToString :: Show t => t -> String
-  pyfToString = show
 
 instance PyFToString String where pyfToString = id
 
@@ -73,4 +129,76 @@ instance PyFToString LText.Text where pyfToString = LText.unpack
 
 instance PyFToString SText.Text where pyfToString = SText.unpack
 
+instance PyFToString Data.ByteString.ByteString where pyfToString = SText.unpack . E.decodeUtf8
+
+instance PyFToString Data.ByteString.Lazy.ByteString where pyfToString = pyfToString . Data.ByteString.Lazy.toStrict
+
+instance PyFToString Char where pyfToString c = [c]
+
+-- | Default instance. Convert any type with a 'Show instance.
 instance {-# OVERLAPPABLE #-} Show t => PyFToString t where pyfToString = show
+
+-- * Real formatting (with optional fractional part)
+
+-- | Apply a fractional formatting to any type.
+--
+-- A default instance for any 'Real' is provided which internally converts to
+-- 'Double', which may not be efficient or results in rounding errors.
+--
+-- You can provide your own instance and internally use 'formatFractional'
+-- which does have the same signatures as 'pyfFormatFractional' but with a
+-- 'RealFrac' constraint.
+class PyfFormatFractional a where
+  pyfFormatFractional ::
+    Format t t' 'Fractional ->
+    -- | Sign formatting
+    SignMode ->
+    -- | Padding
+    Maybe (Int, AlignMode k, Char) ->
+    -- | Grouping
+    Maybe (Int, Char) ->
+    -- | Precision
+    Maybe Int ->
+    a ->
+    String
+
+-- | Default instance working for any 'Real'. Internally it converts the type to 'Double'.
+instance {-# OVERLAPPABLE #-} Real t => PyfFormatFractional t where
+  pyfFormatFractional f s p g prec v = formatFractional f s p g prec (realToFrac @t @Double v)
+
+-- | This instance does not do any conversion.
+instance PyfFormatFractional Double where pyfFormatFractional = formatFractional
+
+-- | This instance does not do any conversion.
+instance PyfFormatFractional Float where pyfFormatFractional = formatFractional
+
+-- * Integral formatting
+
+-- | Apply an integral formatting to any type.
+--
+-- A default instance for any 'Integral' is provided.
+--
+-- You can provide your own instance and internally use 'formatIntegral'
+-- which does have the same signatures as 'pyfFormatIntegral' but with an
+-- 'Integral' constraint.
+class PyfFormatIntegral i where
+  pyfFormatIntegral ::
+    Format t t' 'Integral ->
+    -- | Sign formatting
+    SignMode ->
+    -- | Padding
+    Maybe (Int, AlignMode k, Char) ->
+    -- | Grouping
+    Maybe (Int, Char) ->
+    i ->
+    String
+
+-- | Default instance for any 'Integral'.
+instance {-# OVERLAPPABLE #-} (Show t, Integral t) => PyfFormatIntegral t where
+  pyfFormatIntegral f s p g v = formatIntegral f s p g v
+
+-- | Returns the numerical value of a 'Char'
+-- >>> [fmt|{'a':d}|]
+-- 97
+instance PyfFormatIntegral Char where
+  pyfFormatIntegral f s p g v = formatIntegral f s p g (ord v)

--- a/src/PyF/Internal/QQ.hs
+++ b/src/PyF/Internal/QQ.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
 
 -- | This module uses the python mini language detailed in
 -- 'PyF.Internal.PythonSyntax' to build an template haskell expression
@@ -213,13 +214,13 @@ paddingKToPadding p = case p of
   PaddingK i Nothing -> Padding i Nothing
   PaddingK i (Just (c, a)) -> Padding i (Just (c, AnyAlign a))
 
-formatAnyIntegral :: (Show i, Integral i) => Formatters.Format t t' 'Formatters.Integral -> Formatters.SignMode -> Maybe (Integer, AnyAlign, Char) -> Maybe (Int, Char) -> i -> String
-formatAnyIntegral f s Nothing grouping i = Formatters.formatIntegral f s Nothing grouping i
-formatAnyIntegral f s (Just (padSize, AnyAlign alignMode, c)) grouping i = Formatters.formatIntegral f s (Just (fromIntegral padSize, alignMode, c)) grouping i
+formatAnyIntegral :: PyfFormatIntegral i => Formatters.Format t t' 'Formatters.Integral -> Formatters.SignMode -> Maybe (Integer, AnyAlign, Char) -> Maybe (Int, Char) -> i -> String
+formatAnyIntegral f s Nothing grouping i = pyfFormatIntegral f s Nothing grouping i
+formatAnyIntegral f s (Just (padSize, AnyAlign alignMode, c)) grouping i = pyfFormatIntegral f s (Just (fromIntegral padSize, alignMode, c)) grouping i
 
-formatAnyFractional :: (RealFloat i) => Formatters.Format t t' 'Formatters.Fractional -> Formatters.SignMode -> Maybe (Integer, AnyAlign, Char) -> Maybe (Int, Char) -> Maybe Int -> i -> String
-formatAnyFractional f s Nothing grouping p i = Formatters.formatFractional f s Nothing grouping p i
-formatAnyFractional f s (Just (padSize, AnyAlign alignMode, c)) grouping p i = Formatters.formatFractional f s (Just (fromIntegral padSize, alignMode, c)) grouping p i
+formatAnyFractional :: (PyfFormatFractional i) => Formatters.Format t t' 'Formatters.Fractional -> Formatters.SignMode -> Maybe (Integer, AnyAlign, Char) -> Maybe (Int, Char) -> Maybe Int -> i -> String
+formatAnyFractional f s Nothing grouping p i = pyfFormatFractional f s Nothing grouping p i
+formatAnyFractional f s (Just (padSize, AnyAlign alignMode, c)) grouping p i = pyfFormatFractional f s (Just (fromIntegral padSize, alignMode, c)) grouping p i
 
 class FormatAny i k where
   formatAny :: Formatters.SignMode -> PaddingK k -> Maybe (Int, Char) -> Maybe Int -> i -> String
@@ -233,7 +234,7 @@ class FormatAny2 (c :: PyFCategory) (i :: Type) (k :: Formatters.AlignForString)
 instance (Show t, Integral t) => FormatAny2 'PyFIntegral t k where
   formatAny2 _ s a p _precision = formatAnyIntegral Formatters.Decimal s (newPaddingUnQ (paddingKToPadding a)) p
 
-instance (RealFloat t) => FormatAny2 'PyFFractional t k where
+instance (PyfFormatFractional t) => FormatAny2 'PyFFractional t k where
   formatAny2 _ s a = formatAnyFractional Formatters.Generic s (newPaddingUnQ (paddingKToPadding a))
 
 newPaddingKForString :: PaddingK 'Formatters.AlignAll -> Maybe (Int, Formatters.AlignMode 'Formatters.AlignAll, Char)

--- a/test/SpecFail.hs
+++ b/test/SpecFail.hs
@@ -57,6 +57,7 @@ checkCompile content = withSystemTempFile "PyFTest.hs" $ \path fd -> do
         "-package syb",
         "-package mtl",
         "-package ghc",
+        "-package time",
         "-package containers"
       ]
       ""
@@ -146,13 +147,6 @@ spec =
         failCompile "{hello:+s}"
         failCompile "{hello: s}"
         failCompile "{hello:-s}"
-    describe "number" $ do
-      failCompile "{truncate' number:f}"
-      failCompile "{truncate' number:g}"
-      failCompile "{truncate' number:G}"
-      failCompile "{truncate' number:e}"
-      failCompile "{truncate' number:E}"
-      failCompile "{truncate' number:%}"
     describe "number with precision" $ do
       failCompile "{truncate number:.3d}"
       failCompile "{truncate number:.3o}"

--- a/test/golden/{True:f}.golden
+++ b/test/golden/{True:f}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)

--- a/test/golden/{hello:%}.golden
+++ b/test/golden/{hello:%}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)

--- a/test/golden/{hello:E}.golden
+++ b/test/golden/{hello:E}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)

--- a/test/golden/{hello:G}.golden
+++ b/test/golden/{hello:G}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)

--- a/test/golden/{hello:e}.golden
+++ b/test/golden/{hello:e}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)

--- a/test/golden/{hello:f}.golden
+++ b/test/golden/{hello:f}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)

--- a/test/golden/{hello:g}.golden
+++ b/test/golden/{hello:g}.golden
@@ -1,6 +1,6 @@
 
 INITIALPATH:7:22: error:
-    • No instance for (RealFloat String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
+    • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
     • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
       In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
       In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)


### PR DESCRIPTION
- Added instances for ByteString
- Changed the dependency from RealFrac to Real, which allows multiples
  new "float"-like number to be formatted, including
  `(Nominal)DiffTime`.

Closes #67 and #68.