### PR TITLE
Remove fixity unused code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,8 @@
 # Revision history for PyF
 
-- Remove the dependency to `megaparsec` and replaces it by `parsec`. This should have minor impact on the error messages, however it reduces the dependencies size, because `parsec` is part of the standard `ghc` distribution.
-- *Huge Change*. The parsing of embeded expression does not depend anymore on `haskell-src-ext` and `haskell-src-meta` and instead depends on the built-in `ghc` lib. The direct result is that `PyF` have fewer dependencies. A `stack` build from scratch now takes 35s versus 4 minutes and 20s before.
+- Due to the dependencies refactor, `PyF` no have no dependencies other than the one packaged with GHC. The direct result is that `PyF` build time is reduced to 6s versus 4 minutes and 20s before.
+- Remove the dependency to `megaparsec` and replaces it by `parsec`. This should have minor impact on the error messages.
+- *Huge Change*. The parsing of embeded expression does not depend anymore on `haskell-src-ext` and `haskell-src-meta` and instead depends on the built-in `ghc` lib.
 - Added instances for `(Lazy)ByteString` to `PyFClassify` and `PyFToString`. `ByteString` can now be integrated into format string, and will be decoded as ascii.
 - Relax the constraint for floating point formatting from `RealFrac` to `Real`. As a result, a few new type can be formatted as floating point number. One drawback is that some `Integral` are `Real` too and hence it is not an error anymore to format an integral as floating point, but you still need to explicitly select a floating point formatter.
 - Added instance for `(Nominal)DiffTime` to `PyFClassify`, so you can now format them without conversion.

--- a/PyF.cabal
+++ b/PyF.cabal
@@ -33,12 +33,10 @@ library
                      , template-haskell
                      , text
                      , time
-
                      , parsec
                      , mtl
                      , ghc
                      , ghc-boot
-                     , syb
   hs-source-dirs: src
   ghc-options: -Wall -Wunused-packages -Wincomplete-uni-patterns
   default-language:    Haskell2010

--- a/src/PyF/Internal/ParserEx.hs
+++ b/src/PyF/Internal/ParserEx.hs
@@ -3,17 +3,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -Wno-missing-fields -Wno-name-shadowing -Wno-unused-imports #-}
 {-# LANGUAGE CPP #-}
--- Copyright (c) 2020, Shayne Fletcher. All rights reserved.
--- SPDX-License-Identifier: BSD-3-Clause.
-
--- Note: This code was mostly copied from:
--- https://github.com/shayne-fletcher/ghc-lib-parser-ex
--- Changes done:
---   - integration of the ghc version .h file in top of the file
---   - switch from uniplate to syb in order to reduce dependencies footprint.
---   - Compatibility with GHC >= 9.2
-
-module PyF.Internal.ParserEx (fakeSettings, fakeLlvmConfig, parseExpression, applyFixities, preludeFixities,baseFixities)
+module PyF.Internal.ParserEx (fakeSettings, fakeLlvmConfig, parseExpression)
 where
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Settings.Config
@@ -94,7 +84,6 @@ import OccName
 #endif
 
 import Data.Maybe
-import Data.Generics (everywhere, mkT)
 
 fakeSettings :: Settings
 fakeSettings = Settings
@@ -172,7 +161,6 @@ fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
 fakeLlvmConfig = ([], [])
 #endif
 
-
 -- From Language.Haskell.GhclibParserEx.GHC.Parser
 
 parse :: P a -> String -> DynFlags -> ParseResult a
@@ -204,212 +192,3 @@ parseExpression s flags =
 #else
 parseExpression = parse Parser.parseExpression
 #endif
-
-
--- from Language.Haskell.GhclibParserEx.Fixity.html
-
--- | Rearrange a parse tree to account for fixities.
-applyFixities :: Data a => [(String, Fixity)] -> a -> a
-applyFixities fixities m =
-  let m'  = everywhere (mkT $ expFix fixities) m
-      m'' = everywhere (mkT $ patFix fixities) m'
-  in m''
-
-preludeFixities :: [(String, Fixity)]
-preludeFixities = concat
-    [ infixr_ 9  ["."]
-    , infixl_ 9  ["!!"]
-    , infixr_ 8  ["^","^^","**"]
-    , infixl_ 7  ["*","/","quot","rem","div","mod",":%","%"]
-    , infixl_ 6  ["+","-"]
-    , infixr_ 5  [":","++"]
-    , infix_  4  ["==","/=","<","<=",">=",">","elem","notElem"]
-    , infixr_ 3  ["&&"]
-    , infixr_ 2  ["||"]
-    , infixl_ 1  [">>",">>="]
-    , infixr_ 1  ["=<<"]
-    , infixr_ 0  ["$","$!","seq"]
-    ]
-
--- All fixities defined in the base package. Note that the @+++@
--- operator appears in both Control.Arrows and
--- Text.ParserCombinators.ReadP. The listed precedence for @+++@ in
--- this list is that of Control.Arrows.
-baseFixities :: [(String, Fixity)]
-baseFixities = preludeFixities ++ concat
-    [ infixr_ 9 ["Compose"]
-    , infixl_ 9 ["!","//","!:"]
-    , infixl_ 8 ["shift","rotate","shiftL","shiftR","rotateL","rotateR"]
-    , infixl_ 7 [".&."]
-    , infixl_ 6 ["xor"]
-    , infix_  6 [":+"]
-    , infixr_ 6 ["<>"]
-    , infixl_ 5 [".|."]
-    , infixr_ 5 ["+:+","<++","<+>","<|"] -- Fixity conflict for +++ between ReadP and Arrow.
-    , infix_  5 ["\\\\"]
-    , infixl_ 4 ["<$>","<$","$>","<*>","<*","*>","<**>","<$!>"]
-    , infix_  4 ["elemP","notElemP",":~:", ":~~:"]
-    , infixl_ 3 ["<|>"]
-    , infixr_ 3 ["&&&","***"]
-    , infixr_ 2 ["+++","|||"]
-    , infixr_ 1 ["<=<",">=>",">>>","<<<","^<<","<<^","^>>",">>^"]
-    , infixl_ 0 ["on"]
-    , infixr_ 0 ["par","pseq"]
-    ]
-
-infixr_, infixl_, infix_ :: Int -> [String] -> [(String,Fixity)]
-infixr_ = fixity InfixR
-infixl_ = fixity InfixL
-infix_  = fixity InfixN
-
-fixity :: FixityDirection -> Int -> [String] -> [(String, Fixity)]
-fixity a p = map (,Fixity (SourceText "") p a)
-
-#if MIN_VERSION_ghc(9, 2, 0)
-pattern L' :: SrcSpan -> e -> GenLocated (SrcSpanAnn' (EpAnn ann)) e
-pattern L' loc o = L (SrcSpanAnn EpAnnNotUsed loc) o
-#else
-pattern L' :: l -> e -> GenLocated l e
-pattern L' loc o = L loc o
-#endif
-
-expFix :: [(String, Fixity)] -> LHsExpr GhcPs -> LHsExpr GhcPs
-expFix fixities (L' loc (OpApp _ l op r)) =
-  mkOpApp (getFixities fixities) loc l op (findFixity (getFixities fixities) op) r
-expFix _ e = e
-
--- LPat and Pat have gone through a lot of churn. See
--- https://gitlab.haskell.org/ghc/ghc/merge_requests/1925 for details.
-patFix :: [(String, Fixity)] -> LPat GhcPs -> LPat GhcPs
-#if MIN_VERSION_ghc(9, 0, 0)
-patFix fixities (L loc (ConPat _ op (InfixCon pat1 pat2))) =
-  L loc (mkConOpPat (getFixities fixities) op (findFixity' (getFixities fixities) op) pat1 pat2)
-#elif MIN_VERSION_ghc(8, 10, 0)
-patFix fixities (L' loc (ConPatIn op (InfixCon pat1 pat2))) =
-  L loc (mkConOpPat (getFixities fixities) op (findFixity' (getFixities fixities) op) pat1 pat2)
-#elif MIN_VERSION_ghc(8, 8, 0)
-patFix fixities (dL -> L _ (ConPatIn op (InfixCon pat1 pat2))) =
-  mkConOpPat (getFixities fixities) op (findFixity' (getFixities fixities) op) pat1 pat2
-#else
-patFix fixities (L src (ConPatIn op (InfixCon pat1 pat2))) =
-  L src $ mkConOpPat (getFixities fixities) op (findFixity' (getFixities fixities) op) pat1 pat2
-#endif
-patFix _ p = p
-
-mkConOpPat ::
-  [(String, Fixity)]
-#if MIN_VERSION_ghc(9, 2, 0)
-  -> GenLocated (SrcSpanAnn' (EpAnn NameAnn)) RdrName -> Fixity
-#else
-  -> Located RdrName -> Fixity
-#endif
-  -> LPat GhcPs -> LPat GhcPs
-  -> Pat GhcPs
-#if MIN_VERSION_ghc(9, 2, 0)
-mkConOpPat fs op2 fix2 p1@(L loc (ConPat _ op1 (InfixCon p11 p12))) p2
-#elif MIN_VERSION_ghc(9, 0, 0)
-mkConOpPat fs op2 fix2 p1@(L loc (ConPat _ op1 (InfixCon p11 p12))) p2
-#elif MIN_VERSION_ghc(8, 10, 0)
-mkConOpPat fs op2 fix2 p1@(L loc (ConPatIn op1 (InfixCon p11 p12))) p2
-#elif MIN_VERSION_ghc(8, 8, 0)
-mkConOpPat fs op2 fix2 p1@(dL->L loc (ConPatIn op1 (InfixCon p11 p12))) p2
-#else
-mkConOpPat fs op2 fix2 p1@(L loc (ConPatIn op1 (InfixCon p11 p12))) p2
-#endif
-
-#if MIN_VERSION_ghc(9, 0, 0)
-  | nofix_error = ConPat noExt op2 (InfixCon p1 p2)
-#else
-  | nofix_error = ConPatIn op2 (InfixCon p1 p2)
-#endif
-#if MIN_VERSION_ghc(9, 0, 0)
-  | associate_right = ConPat noExt op1 (InfixCon p11 (L loc (mkConOpPat fs op2 fix2 p12 p2)))
-#elif MIN_VERSION_ghc(8, 10, 0)
-  | associate_right = ConPatIn op1 (InfixCon p11 (L loc (mkConOpPat fs op2 fix2 p12 p2)))
-#elif MIN_VERSION_ghc(8, 8, 0)
-  | associate_right = ConPatIn op1 (InfixCon p11 (cL loc (mkConOpPat fs op2 fix2 p12 p2)))
-#else
-  | associate_right = ConPatIn op1 (InfixCon p11 (L loc $ mkConOpPat fs op2 fix2 p12 p2))
-#endif
-#if MIN_VERSION_ghc(9, 0, 0)
-  | otherwise = ConPat noExt op2 (InfixCon p1 p2)
-#else
-  | otherwise = ConPatIn op2 (InfixCon p1 p2)
-#endif
-  where
-    fix1 = findFixity' fs op1
-    (nofix_error, associate_right) = compareFixity fix1 fix2
-#if MIN_VERSION_ghc(9, 2, 0)
-mkConOpPat _ op _ p1 p2 = ConPat noExt op (InfixCon p1 p2)
-#elif MIN_VERSION_ghc(9, 0, 0)
-mkConOpPat _ op _ p1 p2 = ConPat noExt op (InfixCon p1 p2)
-#else
-mkConOpPat _ op _ p1 p2 = ConPatIn op (InfixCon p1 p2)
-#endif
-
-mkOpApp ::
-  [(String, Fixity)]
-  -> SrcSpan
-  -> LHsExpr GhcPs -- Left operand; already rearrange.
-  -> LHsExpr GhcPs -> Fixity -- Operator and fixity.
-  -> LHsExpr GhcPs -- Right operand (not an OpApp, but might be a NegApp).
-  -> LHsExpr GhcPs
---      (e11 `op1` e12) `op2` e2
-mkOpApp fs loc e1@(L _ (OpApp x1 e11 op1 e12)) op2 fix2 e2
-  | nofix_error = L' loc (OpApp noExt e1 op2 e2)
-  | associate_right = L' loc (OpApp x1 e11 op1 (mkOpApp fs loc' e12 op2 fix2 e2 ))
-  where
-    loc'= combineLocs' e12 e2
-    fix1 = findFixity fs op1
-    (nofix_error, associate_right) = compareFixity fix1 fix2
---      (- neg_arg) `op` e2
-mkOpApp fs loc e1@(L _ (NegApp _ neg_arg neg_name)) op2 fix2 e2
-  | nofix_error = L' loc (OpApp noExt e1 op2 e2)
-  | associate_right = L' loc (NegApp noExt (mkOpApp fs loc' neg_arg op2 fix2 e2) neg_name)
-  where
-    loc' = combineLocs' neg_arg e2
-    (nofix_error, associate_right) = compareFixity negateFixity fix2
---      e1 `op` - neg_arg
-mkOpApp _ loc e1 op1 fix1 e2@(L _ NegApp {}) -- NegApp can occur on the right.
-  | not associate_right  = L' loc (OpApp noExt e1 op1 e2)-- We *want* right association.
-  where
-    (_, associate_right) = compareFixity fix1 negateFixity
- --     Default case, no rearrangment.
-mkOpApp _ loc e1 op _fix e2 = L' loc (OpApp noExt e1 op e2)
-
-#if MIN_VERSION_ghc(9, 2, 0)
-toL = L (UnhelpfulSpan UnhelpfulNoLocationInfo)
-combineLocs' x y = combineLocs (toL x) (toL y)
-#else
-combineLocs' :: LHsExpr GhcPs -> LHsExpr GhcPs -> SrcSpan
-combineLocs' = combineLocs
-#endif
-
-#if MIN_VERSION_ghc(9, 2, 0)
-noExt = EpAnnNotUsed
-#elif MIN_VERSION_ghc(8, 10, 0)
-noExt :: NoExtField
-noExt = noExtField
-#endif
-
-#if MIN_VERSION_ghc(9, 2, 0)
-findFixity' :: [(String, Fixity)] -> LocatedN RdrName -> Fixity
-#else
-findFixity' :: [(String, Fixity)] -> Located RdrName -> Fixity
-#endif
-findFixity' fs r = askFix fs (occNameString . rdrNameOcc . unLoc $ r) -- Patterns.
-
-askFix :: [(String, Fixity)] -> String -> Fixity
-askFix xs = \k -> lookupWithDefault defaultFixity k xs
-  where lookupWithDefault def_v k mp1 = fromMaybe def_v $ lookup k mp1
-
--- If there are no fixities, give 'baseFixities'.
-getFixities :: [(String, Fixity)] -> [(String, Fixity)]
-getFixities fixities = if null fixities then baseFixities else fixities
-
-findFixity :: [(String, Fixity)] -> LHsExpr GhcPs -> Fixity
-findFixity fs r = askFix fs (getIdent r) -- Expressions.
-
-getIdent :: LHsExpr GhcPs -> String
-getIdent (unLoc -> HsVar _ (L _ n)) = occNameString . rdrNameOcc $ n
-getIdent _ = error "Must be HsVar"

--- a/src/PyF/Internal/PythonSyntax.hs
+++ b/src/PyF/Internal/PythonSyntax.hs
@@ -31,7 +31,6 @@ import Language.Haskell.TH.Syntax (Exp)
 import PyF.Formatters
 import PyF.Internal.Meta
 import qualified PyF.Internal.Parser as ParseExp
-import PyF.Internal.ParserEx (applyFixities, baseFixities, preludeFixities)
 import Text.Parsec
 
 type Parser t = ParsecT String () (Reader ParsingContext) t
@@ -230,7 +229,7 @@ evalExpr exts exprParser = do
     Right expr -> do
       -- Consumne the expression
       void exprParser
-      pure (toExp dynFlags (applyFixities (preludeFixities ++ baseFixities) expr))
+      pure (toExp dynFlags expr)
     Left (lineError, colError, err) -> do
       -- Skip lines
       replicateM_ (lineError - 1) (manyTill anyChar newline)

--- a/test/SpecFail.hs
+++ b/test/SpecFail.hs
@@ -54,7 +54,6 @@ checkCompile content = withSystemTempFile "PyFTest.hs" $ \path fd -> do
         "-package text",
         "-package template-haskell",
         "-package ghc-boot",
-        "-package syb",
         "-package mtl",
         "-package ghc",
         "-package time",


### PR DESCRIPTION
All the code in ParseEx.hs which was related to fixity parsing is
naturally handled by template haskell using the `UInfixE` expression,
which defer fixity evaluation to the phase following template haskell.

This dramatically simplify the code, removes the dependency to `syb` and
generally handle fixity.