### PR TITLE
Arbitrary haskell expression for padding width

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for PyF
 
+## 0.10.1.0 -- ?
+
+- Padding width can now be any arbitrary Haskell expression, such as `[fmt|hello pi = {pi:<{5 * 10}}|]`.
+
 ## 0.10.0.1 -- 2021-10-30
 
 - Due to the dependencies refactor, `PyF` no have no dependencies other than the one packaged with GHC. The direct result is that `PyF` build time is reduced to 6s versus 4 minutes and 20s before.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@
 ## 0.10.1.0 -- ?
 
 - Padding width can now be any arbitrary Haskell expression, such as `[fmt|hello pi = {pi:<{5 * 10}}|]`.
+- Precision (and now padding width) arbitrary expression can now be any `Integral` and it is not limited to `Int` anymore.
+- (Meta): type expression are now parsed and hence allowed inside arbitrary Haskell expression for padding width and precision. For example, `[fmt|Hello {pi:.{3 :: Int}}|]`.
 
 ## 0.10.0.1 -- 2021-10-30
 

--- a/Readme.md
+++ b/Readme.md
@@ -145,13 +145,18 @@ You can ignore a line break with `\` if needed. For example:
 
 Will returns `-a\n-b`. Note how the first and last line breaks are ignored.
 
-## Arbitrary value for precision
+## Arbitrary value for precision and padding
 
-The precision field can be any haskell expression instead of a fixed number:
+The precision and padding width fields can be any Haskell expression (including variables) instead of a fixed number:
 
 ```haskell
 >>> [fmt|{pi:.{1+2}}|]
 3.142
+```
+
+```haskell
+>>> [fmt|{1986:^{2 * 10}d}|]
+"        1986        "
 ```
 
 # Output type

--- a/src/PyF/Class.hs
+++ b/src/PyF/Class.hs
@@ -150,15 +150,16 @@ instance {-# OVERLAPPABLE #-} Show t => PyFToString t where pyfToString = show
 -- 'RealFrac' constraint.
 class PyfFormatFractional a where
   pyfFormatFractional ::
+    (Integral paddingWidth, Integral precision) =>
     Format t t' 'Fractional ->
     -- | Sign formatting
     SignMode ->
     -- | Padding
-    Maybe (Int, AlignMode k, Char) ->
+    Maybe (paddingWidth, AlignMode k, Char) ->
     -- | Grouping
     Maybe (Int, Char) ->
     -- | Precision
-    Maybe Int ->
+    Maybe precision ->
     a ->
     String
 
@@ -183,11 +184,12 @@ instance PyfFormatFractional Float where pyfFormatFractional = formatFractional
 -- 'Integral' constraint.
 class PyfFormatIntegral i where
   pyfFormatIntegral ::
+    Integral paddingWidth =>
     Format t t' 'Integral ->
     -- | Sign formatting
     SignMode ->
     -- | Padding
-    Maybe (Int, AlignMode k, Char) ->
+    Maybe (paddingWidth, AlignMode k, Char) ->
     -- | Grouping
     Maybe (Int, Char) ->
     i ->

--- a/src/PyF/Internal/Meta.hs
+++ b/src/PyF/Internal/Meta.hs
@@ -60,6 +60,8 @@ import DynFlags (DynFlags, xopt_set, defaultDynFlags)
 import qualified Module
 #endif
 
+import GHC.Stack
+
 #if MIN_VERSION_ghc(9,2,0)
 -- TODO: why this disapears in GHC >= 9.2?
 fl_value = rationalFromFractionalLit
@@ -193,10 +195,10 @@ toExp d (Expr.ExprWithTySig _ e (HsWC _ (HsIB _ (unLoc -> t)))) = TH.SigE (toExp
 #endif
 toExp dynFlags e = todo "toExp" (showSDocDebug dynFlags . ppr $ e)
 
-todo :: (Show e) => String -> e -> a
+todo :: (HasCallStack, Show e) => String -> e -> a
 todo fun thing = error . concat $ [moduleName, ".", fun, ": not implemented: ", show thing]
 
-noTH :: (Show e) => String -> e -> a
+noTH :: (HasCallStack, Show e) => String -> e -> a
 noTH fun thing = error . concat $ [moduleName, ".", fun, ": no TemplateHaskell for: ", show thing]
 
 moduleName :: String

--- a/src/PyF/Internal/PythonSyntax.hs
+++ b/src/PyF/Internal/PythonSyntax.hs
@@ -155,7 +155,7 @@ data FormatMode = FormatMode Padding TypeFormat (Maybe Char)
 -- | Padding, containing the padding width, the padding char and the alignement mode
 data Padding
   = PaddingDefault
-  | Padding (ExprOrValue Integer) (Maybe (Maybe Char, AnyAlign))
+  | Padding (ExprOrValue Int) (Maybe (Maybe Char, AnyAlign))
   deriving (Show)
 
 -- | Represents a value of type @t@ or an Haskell expression supposed to represents that value
@@ -167,7 +167,7 @@ data ExprOrValue t
 -- | Floating point precision
 data Precision
   = PrecisionDefault
-  | Precision (ExprOrValue Integer)
+  | Precision (ExprOrValue Int)
   deriving (Show)
 
 {-
@@ -274,7 +274,7 @@ formatSpec = do
       Left typeError ->
         fail typeError
 
-parseWidth :: Parser (ExprOrValue Integer)
+parseWidth :: Parser (ExprOrValue Int)
 parseWidth = do
   exts <- asks enabledExtensions
   Just (charOpening, charClosing) <- asks delimiters
@@ -383,16 +383,16 @@ sign =
       Space <$ char ' '
     ]
 
-width :: Parser Integer
+width :: Parser Int
 width = integer
 
-integer :: Parser Integer
+integer :: Parser Int
 integer = read <$> some (oneOf ['0' .. '9']) -- incomplete: see: https://docs.python.org/3/reference/lexical_analysis.html#grammar-token-integer
 
 groupingOption :: Parser Char
 groupingOption = oneOf ("_," :: String)
 
-precision :: Parser Integer
+precision :: Parser Int
 precision = integer
 
 type_ :: Parser TypeFlag

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -243,6 +243,11 @@ spec = do
       do
         let n = 3 :: Int
         [fmt|{pi:.{n}}|] `shouldBe` "3.142"
+  describe "variable padding" $ 
+    it "works" $ 
+      do
+        let n = 5 :: Integer
+        [fmt|Bonjour {'a':>{n}}|] `shouldBe` "Bonjour     a"
   it "escape chars" $
     [fmt|}}{{}}{{|] `shouldBe` "}{}{"
   describe "custom delimiters" $ do

--- a/test/golden/{helloCOLON=100}.golden
+++ b/test/golden/{helloCOLON=100}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • String type is incompatible with inside padding (=).
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK 100) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK 100) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK 100) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:=100}|]
   |                      ^^^^^^^^^^^^^^


### PR DESCRIPTION
- Padding width can now be any arbitrary Haskell expression, such as `[fmt|hello pi = {pi:<{5 * 10}}|]`.
- Precision (and now padding width) arbitrary expression can now be any `Integral` and it is not limited to `Int` anymore.
- (Meta): type expression are now parsed and hence allowed inside arbitrary Haskell expression for padding width and precision. For example, `[fmt|Hello {pi:.{3 :: Int}}|]`.
