### PR TITLE
Fix int default and add type syn

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # Revision history for PyF
 
+- Support for `::` in haskell expression. Such as `[fmt| 10 :: Int:d}|]`, as a suggestion from julm (close #87).
+
 ## 0.10.1.0 -- 2021-12-05
 
 - Padding width can now be any arbitrary Haskell expression, such as `[fmt|hello pi = {pi:<{5 * 10}}|]`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 # Revision history for PyF
 
 - Support for `::` in haskell expression. Such as `[fmt| 10 :: Int:d}|]`, as a suggestion from julm (close #87).
+- `Integral` padding width and precision also for formatter without type specifier.
+- Extra care was used to catch all `type-defaults` warning message. PyF should
+  not generate code with this kind of warning, unless the embedded Haskell
+  expression are ambiguous (e.g. `[fmt|{10}|]`). You can use `::` to
+  disambiguate, e.g. `[fmt|{10 :: Int}|]`.
 
 ## 0.10.1.0 -- 2021-12-05
 

--- a/Readme.md
+++ b/Readme.md
@@ -292,7 +292,7 @@ The implementation is unit-tested against the reference python implementation (p
 ### Not supported
 
 - Number `n` formatter is not supported. In python this formatter can format a number and use current locale information for decimal part and thousand separator. There is no plan to support that because of the impure interface needed to read the locale.
-- Python support sub variables in the formatting options in every places, such as `{expression:.{precision}}`. We only support it for `precision`. This is more complexe to setup for others fields.
+- Python support sub variables in the formatting options in every places, such as `{expression:.{precision}}`. We only support it for `precision` and `width`. This is more complexe to setup for others fields.
 - Python literal integers accepts binary/octal/hexa/decimal literals, PyF only accept decimal ones, I don't have a plan to support that, if you really need to format a float with a number of digit provided as a binary constant, open an issue.
 - Python support adding custom formatters for new types, such as date. This may be really cool, for example `[fmt|{today:%Y-%M-%D}`. I don't know how to support that now.
 

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,0 @@
-{ pkgs ? import ./nixpkgs.nix {}}:
-with pkgs;
-rec

--- a/src/PyF/Formatters.hs
+++ b/src/PyF/Formatters.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 -- |
 --
@@ -304,17 +306,19 @@ formatFractional f sign padding grouping precision i = padAndSign f "" sign padd
 
 -- | Format a string
 formatString ::
+  forall paddingWidth precision.
+  (Integral paddingWidth, Integral precision) =>
   -- | Padding
-  Maybe (Int, AlignMode 'AlignAll, Char) ->
+  Maybe (paddingWidth, AlignMode 'AlignAll, Char) ->
   -- | Precision (will truncate before padding)
-  Maybe Int ->
+  Maybe precision ->
   String ->
   String
 formatString Nothing Nothing s = s
-formatString Nothing (Just i) s = take i s
-formatString (Just (padSize, padMode, padC)) size s = padLeft <> str <> padRight
+formatString Nothing (Just i) s = take (fromIntegral i) s
+formatString (Just (fromIntegral -> padSize, padMode, padC)) size s = padLeft <> str <> padRight
   where
-    str = formatString Nothing size s
+    str = formatString @paddingWidth Nothing size s
     paddingLength = max 0 (padSize - length str)
     (padLeft, padRight) = case padMode of
       AlignLeft -> ("", replicate paddingLength padC)

--- a/src/PyF/Internal/Meta.hs
+++ b/src/PyF/Internal/Meta.hs
@@ -7,13 +7,13 @@
 module PyF.Internal.Meta (toExp, baseDynFlags, translateTHtoGHCExt) where
 
 #if MIN_VERSION_ghc(9,2,0)
-import GHC.Hs.Type (HsWildCardBndrs (..), HsType (..), HsSigType(HsSig))
+import GHC.Hs.Type (HsWildCardBndrs (..), HsType (..), HsSigType(HsSig), sig_body)
 #elif MIN_VERSION_ghc(9,0,0)
-import GHC.Hs.Type (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs(HsIB))
+import GHC.Hs.Type (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs(HsIB), hsib_body)
 #elif MIN_VERSION_ghc(8,10,0)
-import GHC.Hs.Types (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs (HsIB))
+import GHC.Hs.Types (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs (HsIB, hsib_body))
 #else
-import HsTypes (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs (HsIB))
+import HsTypes (HsWildCardBndrs (..), HsType (..), HsImplicitBndrs (HsIB), hsib_body)
 #endif
 
 #if MIN_VERSION_ghc(8,10,0)
@@ -129,8 +129,12 @@ toExp _ Expr.HsIPVar {} = noTH "toExp" "HsIPVar"
 toExp _ (Expr.HsLit _ l) = TH.LitE (toLit l)
 toExp _ (Expr.HsOverLit _ OverLit {ol_val}) = TH.LitE (toLit' ol_val)
 toExp d (Expr.HsApp _ e1 e2) = TH.AppE (toExp d . unLoc $ e1) (toExp d . unLoc $ e2)
-#if MIN_VERSION_ghc(8,8,0)
+#if MIN_VERSION_ghc(9,2,0)
 toExp d (Expr.HsAppType _ e HsWC {hswc_body}) = TH.AppTypeE (toExp d . unLoc $ e) (toType . unLoc $ hswc_body)
+toExp d (Expr.ExprWithTySig _ e HsWC{hswc_body=unLoc -> HsSig{sig_body}}) = TH.SigE (toExp d . unLoc $ e) (toType . unLoc $ sig_body)
+#elif MIN_VERSION_ghc(8,8,0)
+toExp d (Expr.HsAppType _ e HsWC {hswc_body}) = TH.AppTypeE (toExp d . unLoc $ e) (toType . unLoc $ hswc_body)
+toExp d (Expr.ExprWithTySig _ e HsWC{hswc_body=HsIB{hsib_body}}) = TH.SigE (toExp d . unLoc $ e) (toType . unLoc $ hsib_body)
 #else
 toExp d (Expr.HsAppType HsWC {hswc_body} e) = TH.AppTypeE (toExp d . unLoc $ e) (toType . unLoc $ hswc_body)
 #endif
@@ -188,11 +192,6 @@ toExp d (Expr.ArithSeq _ _ e) = TH.ArithSeqE $ case e of
   (FromThen a b) -> TH.FromThenR (toExp d $ unLoc a) (toExp d $ unLoc b)
   (FromTo a b) -> TH.FromToR (toExp d $ unLoc a) (toExp d $ unLoc b)
   (FromThenTo a b c) -> TH.FromThenToR (toExp d $ unLoc a) (toExp d $ unLoc b) (toExp d $ unLoc c)
-#if MIN_VERSION_ghc(9, 2, 0)
-toExp d (Expr.ExprWithTySig _ e (HsWC _ (unLoc -> HsSig _ _ (unLoc -> t)))) = TH.SigE (toExp d (unLoc e)) (toType t)
-#elif MIN_VERSION_ghc(9, 0, 0)
-toExp d (Expr.ExprWithTySig _ e (HsWC _ (HsIB _ (unLoc -> t)))) = TH.SigE (toExp d (unLoc e)) (toType t)
-#endif
 toExp dynFlags e = todo "toExp" (showSDocDebug dynFlags . ppr $ e)
 
 todo :: (HasCallStack, Show e) => String -> e -> a

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -490,3 +490,15 @@ yeah\
   - b {pi}
   |]
         `shouldBe` "- a \b {\n- b {pi}\n"
+
+  describe "handle ::" $ do
+    it "works in simple context" $ do
+      [fmt|{-10 :: Int:d}|] `shouldBe` "-10"
+    it "works in a padding = context" $ do
+      [fmt|{-10 :: Int::=10d}|] `shouldBe` "-:::::::10"
+    it "works in a padding < context" $ do
+      [fmt|{-10 :: Int::<10d}|] `shouldBe` "-10:::::::"
+    it "works in a padding > context" $ do
+      [fmt|{-10 :: Int::>10d}|] `shouldBe` ":::::::-10"
+    it "works in a padding ^ context" $ do
+      [fmt|{-10 :: Int::^10d}|] `shouldBe` ":::-10::::"

--- a/test/golden/hello { world.golden
+++ b/test/golden/hello { world.golden
@@ -6,7 +6,7 @@ INITIALPATH:7:22: error:
   |                                   ^
 
 unexpected end of input
-expecting ":" or "}"
+expecting "::", ":" or "}"
 
     • In the quasi-quotation: [fmt|hello { world|]
   |

--- a/test/golden/{TrueCOLONd}.golden
+++ b/test/golden/{TrueCOLONd}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) True)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) True)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) True)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) True)
   |
 7 | main = putStrLn [fmt|{True:d}|]
   |                      ^^^^^^^^^^

--- a/test/golden/{TrueCOLONf}.golden
+++ b/test/golden/{TrueCOLONf}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real Bool) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) True)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) True)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) True)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) True)
   |
 7 | main = putStrLn [fmt|{True:f}|]
   |                      ^^^^^^^^^^

--- a/test/golden/{True}.golden
+++ b/test/golden/{True}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (PyF.Internal.QQ.FormatAny2 (PyFClassify Bool) Bool 'PyF.Formatters.AlignAll) arising from a use of ‘PyF.Internal.QQ.formatAny’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) Nothing) True)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) (Nothing :: Maybe Int)) True)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) (Nothing :: Maybe Int)) True)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) PyF.Internal.QQ.PaddingDefaultK) Nothing) (Nothing :: Maybe Int)) True)
   |
 7 | main = putStrLn [fmt|{True}|]
   |                      ^^^^^^^^

--- a/test/golden/{helloCOLON%}.golden
+++ b/test/golden/{helloCOLON%}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Percent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:%}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLON=100}.golden
+++ b/test/golden/{helloCOLON=100}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • String type is incompatible with inside padding (=).
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (fromIntegral (100 :: Int))) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (100 :: Int)) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) (Nothing :: Maybe Int)) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (100 :: Int)) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) (Nothing :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAny PyF.Formatters.Minus) ((PyF.Internal.QQ.PaddingK (100 :: Int)) (Just (Nothing, PyF.Formatters.AlignInside)))) Nothing) (Nothing :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:=100}|]
   |                      ^^^^^^^^^^^^^^

--- a/test/golden/{helloCOLONE}.golden
+++ b/test/golden/{helloCOLONE}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Exponent)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:E}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONG}.golden
+++ b/test/golden/{helloCOLONG}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional (PyF.Formatters.Upper PyF.Formatters.Generic)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:G}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONX}.golden
+++ b/test/golden/{helloCOLONX}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral String) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:X}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONb}.golden
+++ b/test/golden/{helloCOLONb}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral String) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:b}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONd}.golden
+++ b/test/golden/{helloCOLONd}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral String) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:d}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONe}.golden
+++ b/test/golden/{helloCOLONe}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Exponent) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:e}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONf}.golden
+++ b/test/golden/{helloCOLONf}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Fixed) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:f}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONg}.golden
+++ b/test/golden/{helloCOLONg}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Real String) arising from a use of ‘PyF.Internal.QQ.formatAnyFractional’
-    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)’
-      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
-      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) Nothing) Nothing) (Just 6)) hello)
+    • In the first argument of ‘putStrLn’, namely ‘((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)’
+      In the expression: putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
+      In an equation for ‘main’: main = putStrLn ((((((PyF.Internal.QQ.formatAnyFractional PyF.Formatters.Generic) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) (Just 6 :: Maybe Int)) hello)
   |
 7 | main = putStrLn [fmt|{hello:g}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONo}.golden
+++ b/test/golden/{helloCOLONo}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral String) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:o}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{helloCOLONx}.golden
+++ b/test/golden/{helloCOLONx}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral String) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) hello)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) hello)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) hello)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) hello)
   |
 7 | main = putStrLn [fmt|{hello:x}|]
   |                      ^^^^^^^^^^^

--- a/test/golden/{numberCOLONX}.golden
+++ b/test/golden/{numberCOLONX}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Float) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) number)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) number)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) Nothing) Nothing) number)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral (PyF.Formatters.Upper PyF.Formatters.Hexa)) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
   |
 7 | main = putStrLn [fmt|{number:X}|]
   |                      ^^^^^^^^^^^^

--- a/test/golden/{numberCOLONb}.golden
+++ b/test/golden/{numberCOLONb}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Float) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) number)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) number)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) Nothing) Nothing) number)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Binary) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
   |
 7 | main = putStrLn [fmt|{number:b}|]
   |                      ^^^^^^^^^^^^

--- a/test/golden/{numberCOLONd}.golden
+++ b/test/golden/{numberCOLONd}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Float) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) number)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) number)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) Nothing) Nothing) number)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Decimal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
   |
 7 | main = putStrLn [fmt|{number:d}|]
   |                      ^^^^^^^^^^^^

--- a/test/golden/{numberCOLONo}.golden
+++ b/test/golden/{numberCOLONo}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Float) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) number)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) number)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) Nothing) Nothing) number)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Octal) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
   |
 7 | main = putStrLn [fmt|{number:o}|]
   |                      ^^^^^^^^^^^^

--- a/test/golden/{numberCOLONx}.golden
+++ b/test/golden/{numberCOLONx}.golden
@@ -1,9 +1,9 @@
 
 INITIALPATH:7:22: error:
     • No instance for (Integral Float) arising from a use of ‘PyF.Internal.QQ.formatAnyIntegral’
-    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) number)’
-      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) number)
-      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) Nothing) Nothing) number)
+    • In the first argument of ‘putStrLn’, namely ‘(((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)’
+      In the expression: putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
+      In an equation for ‘main’: main = putStrLn (((((PyF.Internal.QQ.formatAnyIntegral PyF.Formatters.Hexa) PyF.Formatters.Minus) (Nothing :: Maybe (Int, PyF.Formatters.AnyAlign, Char))) Nothing) number)
   |
 7 | main = putStrLn [fmt|{number:x}|]
   |                      ^^^^^^^^^^^^


### PR DESCRIPTION
Add support for `::` in embedded Haskell expression. Close #87.