### PR TITLE
Ghc 922

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -131,16 +131,17 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1637504714,
-        "narHash": "sha256-2jVo0vA/Gyprc0vfGB6hC8p8ELyeELr+w65pOgtcyoU=",
-        "owner": "NixOS",
+        "lastModified": 1650847071,
+        "narHash": "sha256-fEq5rKXcDvzg6q/v3uRPHdSJ3fSOAczd3eSnKFr+JWk=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1debd0c7540957969626394e3aae19cc8f99eef8",
+        "rev": "b43d3db76831cb80db01dd2ed50d66175fa2a325",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "pre-commit-hooks": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.hls.url = "github:haskell/haskell-language-server";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
 
   # Broken: see https://github.com/NixOS/nix/issues/5621
   #nixConfig.allow-import-from-derivation = true;
@@ -75,11 +76,11 @@
             overrides = self: super: with haskell.lib; { };
           });
 
-          pyf_90 = pyfBuilder (haskell.packages.ghc901.override {
+          pyf_90 = pyfBuilder (haskell.packages.ghc902.override {
             overrides = self: super: with haskell.lib; { };
           });
 
-          pyf_92 = pyfBuilder (haskell.packages.ghc921.override {
+          pyf_92 = pyfBuilder (haskell.packages.ghc922.override {
               overrides = self: super: with haskell.lib; rec { };
           });
 

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   # Broken: see https://github.com/NixOS/nix/issues/5621
   #nixConfig.allow-import-from-derivation = true;
   nixConfig.extra-substituters = [
-    "guibou.cachix.net"
+    "guibou.cachix.org"
     "https://haskell-language-server.cachix.org"
   ];
   nixConfig.extra-trusted-public-keys = [


### PR DESCRIPTION
This is a bump of the nixpkgs to work with GHC 9.2.2.

This is also related to #97 which shows test failures with GHC 9.2.2 on macos X.

Here I cannot reproduce the test, but I will try to add a macosX testing instance in this CI.