### PR TITLE
Feat: use GHC native error reporting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for PyF
 
+- Error reporting now uses the native GHC API. In summary, it means that
+ haskell-language-server will point to the correct location of the error, not
+ the beginning of the quasi quotes.
+- Add support for literal `[]` and `()` in haskell expression.
+- Add support for overloaded labels, thank you Shimuuar.
 - Support for `::` in haskell expression. Such as `[fmt| 10 :: Int:d}|]`, as a suggestion from julm (close #87).
 - `Integral` padding width and precision also for formatter without type specifier.
 - Extra care was used to catch all `type-defaults` warning message. PyF should

--- a/test/golden/fooBACKSLASHPbar.golden
+++ b/test/golden/fooBACKSLASHPbar.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:25:
-  |
-7 | main = putStrLn [fmt|foo\Pbar|]
-  |                         ^
-Lexical error in literal section
+INITIALPATH:7:25: error:
+    • Lexical error in literal section
 
     • In the quasi-quotation: [fmt|foo\Pbar|]
   |
 7 | main = putStrLn [fmt|foo\Pbar|]
-  |                      ^^^^^^^^^^
+  |                         ^

--- a/test/golden/fooNEWLINEbliBACKSLASHPbar.golden
+++ b/test/golden/fooNEWLINEbliBACKSLASHPbar.golden
@@ -1,13 +1,9 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:8:4:
-  |
-8 | bli\Pbar|]
-  |    ^
-Lexical error in literal section
+INITIALPATH:8:4: error:
+    • Lexical error in literal section
 
     • In the quasi-quotation: [fmt|foo
 bli\Pbar|]
   |
-7 | main = putStrLn [fmt|foo
-  |                      ^^^...
+8 | bli\Pbar|]
+  |    ^

--- a/test/golden/hello { world.golden
+++ b/test/golden/hello { world.golden
@@ -1,14 +1,10 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:35:
-  |
-7 | main = putStrLn [fmt|hello { world|]
-  |                                   ^
-
+INITIALPATH:7:35: error:
+    • 
 unexpected end of input
 expecting "::", ":" or "}"
 
     • In the quasi-quotation: [fmt|hello { world|]
   |
 7 | main = putStrLn [fmt|hello { world|]
-  |                      ^^^^^^^^^^^^^^^
+  |                                   ^

--- a/test/golden/hello } world.golden
+++ b/test/golden/hello } world.golden
@@ -1,14 +1,10 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:28:
-  |
-7 | main = putStrLn [fmt|hello } world|]
-  |                            ^
-
+INITIALPATH:7:28: error:
+    • 
 unexpected '}'
 expecting "{{", "}}", "{" or end of input
 
     • In the quasi-quotation: [fmt|hello } world|]
   |
 7 | main = putStrLn [fmt|hello } world|]
-  |                      ^^^^^^^^^^^^^^^
+  |                            ^

--- a/test/golden/helloNEWLINE    {NEWLINElet a = 5NEWLINE    b = 10NEWLINEin 1 + - SLASH lalalal}.golden
+++ b/test/golden/helloNEWLINE    {NEWLINElet a = 5NEWLINE    b = 10NEWLINEin 1 + - SLASH lalalal}.golden
@@ -1,16 +1,12 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:11:10:
-   |
-11 | in 1 + - / lalalal}|]
-   |          ^
-parse error on input `/' in haskell expression
+INITIALPATH:11:10: error:
+    • parse error on input `/' in haskell expression
 
     • In the quasi-quotation: [fmt|hello
     {
 let a = 5
     b = 10
 in 1 + - / lalalal}|]
-  |
-7 | main = putStrLn [fmt|hello
-  |                      ^^^^^...
+   |
+11 | in 1 + - / lalalal}|]
+   |          ^

--- a/test/golden/helloNEWLINENEWLINENEWLINE{piCOLONl}.golden
+++ b/test/golden/helloNEWLINENEWLINENEWLINE{piCOLONl}.golden
@@ -1,10 +1,6 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:10:6:
-   |
-10 | {pi:l}|]
-   |      ^
-
+INITIALPATH:10:6: error:
+    • 
 unexpected "}"
 expecting "<", ">", "^" or "="
 
@@ -12,6 +8,6 @@ expecting "<", ">", "^" or "="
 
 
 {pi:l}|]
-  |
-7 | main = putStrLn [fmt|hello
-  |                      ^^^^^...
+   |
+10 | {pi:l}|]
+   |      ^

--- a/test/golden/{1 + - SLASH lalalal}.golden
+++ b/test/golden/{1 + - SLASH lalalal}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:29:
-  |
-7 | main = putStrLn [fmt|{1 + - / lalalal}|]
-  |                             ^
-parse error on input `/' in haskell expression
+INITIALPATH:7:29: error:
+    • parse error on input `/' in haskell expression
 
     • In the quasi-quotation: [fmt|{1 + - / lalalal}|]
   |
 7 | main = putStrLn [fmt|{1 + - / lalalal}|]
-  |                      ^^^^^^^^^^^^^^^^^^^
+  |                             ^

--- a/test/golden/{helloCOLON s}.golden
+++ b/test/golden/{helloCOLON s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:30:
-  |
-7 | main = putStrLn [fmt|{hello: s}|]
-  |                              ^
-Type incompatible with sign field ( ), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
+INITIALPATH:7:30: error:
+    • Type incompatible with sign field ( ), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
 
     • In the quasi-quotation: [fmt|{hello: s}|]
   |
 7 | main = putStrLn [fmt|{hello: s}|]
-  |                      ^^^^^^^^^^^^
+  |                              ^

--- a/test/golden/{helloCOLON+s}.golden
+++ b/test/golden/{helloCOLON+s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:30:
-  |
-7 | main = putStrLn [fmt|{hello:+s}|]
-  |                              ^
-Type incompatible with sign field (+), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
+INITIALPATH:7:30: error:
+    • Type incompatible with sign field (+), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
 
     • In the quasi-quotation: [fmt|{hello:+s}|]
   |
 7 | main = putStrLn [fmt|{hello:+s}|]
-  |                      ^^^^^^^^^^^^
+  |                              ^

--- a/test/golden/{helloCOLON,s}.golden
+++ b/test/golden/{helloCOLON,s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:30:
-  |
-7 | main = putStrLn [fmt|{hello:,s}|]
-  |                              ^
-String type is incompatible with grouping (_ or ,).
+INITIALPATH:7:30: error:
+    • String type is incompatible with grouping (_ or ,).
 
     • In the quasi-quotation: [fmt|{hello:,s}|]
   |
 7 | main = putStrLn [fmt|{hello:,s}|]
-  |                      ^^^^^^^^^^^^
+  |                              ^

--- a/test/golden/{helloCOLON-s}.golden
+++ b/test/golden/{helloCOLON-s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:30:
-  |
-7 | main = putStrLn [fmt|{hello:-s}|]
-  |                              ^
-Type incompatible with sign field (-), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
+INITIALPATH:7:30: error:
+    • Type incompatible with sign field (-), use any of {'b', 'd', 'e', 'E', 'f', 'F', 'g', 'G', 'n', 'o', 'x', 'X', '%'} or remove the sign field.
 
     • In the quasi-quotation: [fmt|{hello:-s}|]
   |
 7 | main = putStrLn [fmt|{hello:-s}|]
-  |                      ^^^^^^^^^^^^
+  |                              ^

--- a/test/golden/{helloCOLON=100s}.golden
+++ b/test/golden/{helloCOLON=100s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:33:
-  |
-7 | main = putStrLn [fmt|{hello:=100s}|]
-  |                                 ^
-String type is incompatible with inside padding (=).
+INITIALPATH:7:33: error:
+    • String type is incompatible with inside padding (=).
 
     • In the quasi-quotation: [fmt|{hello:=100s}|]
   |
 7 | main = putStrLn [fmt|{hello:=100s}|]
-  |                      ^^^^^^^^^^^^^^^
+  |                                 ^

--- a/test/golden/{helloCOLON_s}.golden
+++ b/test/golden/{helloCOLON_s}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:30:
-  |
-7 | main = putStrLn [fmt|{hello:_s}|]
-  |                              ^
-String type is incompatible with grouping (_ or ,).
+INITIALPATH:7:30: error:
+    • String type is incompatible with grouping (_ or ,).
 
     • In the quasi-quotation: [fmt|{hello:_s}|]
   |
 7 | main = putStrLn [fmt|{hello:_s}|]
-  |                      ^^^^^^^^^^^^
+  |                              ^

--- a/test/golden/{piCOLON.{SLASH}}.golden
+++ b/test/golden/{piCOLON.{SLASH}}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:28:
-  |
-7 | main = putStrLn [fmt|{pi:.{/}}|]
-  |                            ^
-parse error on input `/' in haskell expression
+INITIALPATH:7:28: error:
+    • parse error on input `/' in haskell expression
 
     • In the quasi-quotation: [fmt|{pi:.{/}}|]
   |
 7 | main = putStrLn [fmt|{pi:.{/}}|]
-  |                      ^^^^^^^^^^^
+  |                            ^

--- a/test/golden/{piCOLON.{}}.golden
+++ b/test/golden/{piCOLON.{}}.golden
@@ -1,14 +1,10 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:28:
-  |
-7 | main = putStrLn [fmt|{pi:.{}}|]
-  |                            ^
-
+INITIALPATH:7:28: error:
+    • 
 unexpected "}"
 expecting an haskell expression
 
     • In the quasi-quotation: [fmt|{pi:.{}}|]
   |
 7 | main = putStrLn [fmt|{pi:.{}}|]
-  |                      ^^^^^^^^^^
+  |                            ^

--- a/test/golden/{truncate numberCOLON.3b}.golden
+++ b/test/golden/{truncate numberCOLON.3b}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:41:
-  |
-7 | main = putStrLn [fmt|{truncate number:.3b}|]
-  |                                         ^
-Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
+INITIALPATH:7:41: error:
+    • Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
 
     • In the quasi-quotation: [fmt|{truncate number:.3b}|]
   |
 7 | main = putStrLn [fmt|{truncate number:.3b}|]
-  |                      ^^^^^^^^^^^^^^^^^^^^^^^
+  |                                         ^

--- a/test/golden/{truncate numberCOLON.3d}.golden
+++ b/test/golden/{truncate numberCOLON.3d}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:41:
-  |
-7 | main = putStrLn [fmt|{truncate number:.3d}|]
-  |                                         ^
-Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
+INITIALPATH:7:41: error:
+    • Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
 
     • In the quasi-quotation: [fmt|{truncate number:.3d}|]
   |
 7 | main = putStrLn [fmt|{truncate number:.3d}|]
-  |                      ^^^^^^^^^^^^^^^^^^^^^^^
+  |                                         ^

--- a/test/golden/{truncate numberCOLON.3o}.golden
+++ b/test/golden/{truncate numberCOLON.3o}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:41:
-  |
-7 | main = putStrLn [fmt|{truncate number:.3o}|]
-  |                                         ^
-Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
+INITIALPATH:7:41: error:
+    • Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
 
     • In the quasi-quotation: [fmt|{truncate number:.3o}|]
   |
 7 | main = putStrLn [fmt|{truncate number:.3o}|]
-  |                      ^^^^^^^^^^^^^^^^^^^^^^^
+  |                                         ^

--- a/test/golden/{truncate numberCOLON.3x}.golden
+++ b/test/golden/{truncate numberCOLON.3x}.golden
@@ -1,12 +1,8 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:41:
-  |
-7 | main = putStrLn [fmt|{truncate number:.3x}|]
-  |                                         ^
-Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
+INITIALPATH:7:41: error:
+    • Type incompatible with precision (.3), use any of {'e', 'E', 'f', 'F', 'g', 'G', 'n', 's', '%'} or remove the precision field.
 
     • In the quasi-quotation: [fmt|{truncate number:.3x}|]
   |
 7 | main = putStrLn [fmt|{truncate number:.3x}|]
-  |                      ^^^^^^^^^^^^^^^^^^^^^^^
+  |                                         ^

--- a/test/golden/{}.golden
+++ b/test/golden/{}.golden
@@ -1,14 +1,10 @@
 
-INITIALPATH:7:22: error:
-    • INITIALPATH:7:23:
-  |
-7 | main = putStrLn [fmt|{}|]
-  |                       ^
-
+INITIALPATH:7:23: error:
+    • 
 unexpected "}"
 expecting an haskell expression
 
     • In the quasi-quotation: [fmt|{}|]
   |
 7 | main = putStrLn [fmt|{}|]
-  |                      ^^^^
+  |                       ^


### PR DESCRIPTION
Instead of manually generating the error message with line / caret / ...
and passing this string to TH `fail`, we use GHC native error reporting
functionality.

The benefits are:
- Less code (all the manual formatting code is removed)
- More in sync with other errors
- KILLER FEATURE: the error location is now correctly reported by external
  tools, such as haskell-language-server. No more error spanning over
  your complete template haskell splice, the correct error will be
  pinpointed accurately.

This was achieved using an `unsafeCoerce`, to access the complete GHC
api. I've found about this hack when reading GHC source code and later
found that it was described in

https://www.tweag.io/blog/2021-01-07-haskell-dark-arts-part-i/