### PR TITLE
Do not use unsafeRunTcM for variable lookup

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Revision history for PyF
 
 - Support for OverloadedRecordsDot syntax in Meta. Thank you @Profpatsch for the report.
+- In some context, the error reporting for variable not found in the quasi quote expression was incorrectly reporting existing variables as not found. See https://github.com/guibou/PyF/issues/115 for details. This is now fixed by not abusing GHC api. Thank you @michaelpj for reporting this really weird problem.
 
 ## 0.11.0.0 -- 2022-08-10
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -35,6 +35,7 @@ import PyF
 import SpecCustomDelimiters
 import SpecUtils
 import Test.Hspec
+import qualified Data.Text as Text
 
 {-
    - Normal tests are done using the recommanded API: [fmt|.....|]
@@ -546,3 +547,5 @@ yeah\
       let padding = 10
       let precision = 3
       [fmt|pi = {pi:{padding}.{precision}}|] `shouldBe` "pi =      3.142"
+    it "an expression with module.variable" $ do
+      [fmt|{Text.intercalate " " ["a" :: Text.Text, "b" :: Text.Text]}|] `shouldBe` "a b"


### PR DESCRIPTION
It closes https://github.com/guibou/PyF/issues/115.

In some context, that I don't really understand, the usage of
`unsafeRunTcM` to lookup for the existence of variables returned false
negative.

This is fixed by not using `unsafeRunTcM`, but instead the official
template haskell API.