### PR TITLE
More explicit imports to support more mtl versions

### DIFF
--- a/src/PyF/Internal/PythonSyntax.hs
+++ b/src/PyF/Internal/PythonSyntax.hs
@@ -25,7 +25,8 @@ module PyF.Internal.PythonSyntax
 where
 
 import Control.Applicative (some)
-import Control.Monad.Reader
+import Control.Monad (replicateM_, void)
+import Control.Monad.Reader (Reader, asks)
 import qualified Data.Char
 import Data.Maybe (fromMaybe)
 import GHC (GhcPs, HsExpr)


### PR DESCRIPTION
This is required to allow this package to be compiled against `2.2.*` and `2.3.*` of mtl. Tested with `ghc-8.10` and `ghc-9.6`. With `ghc-8.10`:
  * cabal build all --constraint "mtl ^>= 2.2"
  * cabal build all --constraint "mtl ^>= 2.3"