### PR TITLE
Make it build with ghc-9.8

### DIFF
--- a/PyF.cabal
+++ b/PyF.cabal
@@ -27,10 +27,10 @@ library
                   PyF.Internal.ParserEx
                   PyF.Internal.Parser
 
-  build-depends:       base >= 4.12 && < 4.19
-                     , bytestring >= 0.10.8 && < 0.12
-                     , template-haskell >= 2.14.0 && < 2.21
-                     , text >= 1.2.3 && <= 2.1
+  build-depends:       base >= 4.12 && < 4.21
+                     , bytestring >= 0.10.8 && < 0.13
+                     , template-haskell >= 2.14.0 && < 2.23
+                     , text >= 1.2.3 && <= 2.2
                      , time >= 1.8.0 && < 1.13
                      , parsec >= 3.1.13 && < 3.2
                      , mtl >= 2.2.2 && < 2.4


### PR DESCRIPTION
This PR allows the main `PyF` library to build with `ghc-9.8.0.20230822`.

The tests currently do not build because dependencies (eg `splitmix` and probably others) need to be updated.