### PR TITLE
Meta: add HsProjection for GHC >9.6

### DIFF
--- a/src/PyF/Internal/Meta.hs
+++ b/src/PyF/Internal/Meta.hs
@@ -260,6 +260,7 @@ toExp _ (HsOverLabel _ Nothing lbl) = TH.LabelE (unpackFS lbl)
 #endif
 #if MIN_VERSION_ghc(9,6,0)
 toExp dynFlags (HsGetField _ expr field) = TH.GetFieldE (toExp dynFlags (unLoc expr)) (unpackFS . field_label . unLoc . dfoLabel . unLoc $ field)
+toExp _ (HsProjection _ fields) = TH.ProjectionE (fmap (unpackFS . unLoc . fmap field_label . dfoLabel . unLoc) fields)
 #elif MIN_VERSION_ghc(9, 4, 0)
 toExp dynFlags (HsGetField _ expr field) = TH.GetFieldE (toExp dynFlags (unLoc expr)) (unpackFS . unLoc . dfoLabel . unLoc $ field)
 toExp _ (HsProjection _ fields) = TH.ProjectionE (fmap (unpackFS . unLoc . dfoLabel . unLoc) fields)


### PR DESCRIPTION
It was missing, so record projection functions like `(.myfield.nested)` did not work anymore.

Fixes https://github.com/guibou/PyF/issues/135