### PR TITLE
fix for GHC 9.10

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,9 +7,14 @@ on:
     branches: [ main ]
 
 jobs:
-  nix_build:
+  nix_matrix:
+    strategy:
+      matrix:
+        # 88 is not in nixpkgs anymore
+        # 910 does not build yet for unknown reason
+        # We are not using nix build .#pyf_all because of github disk limitations
+        ghc: [86, 90, 92, 94, 96, 98]
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v21
@@ -19,8 +24,8 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
     # Builds cabal (nix)
-    - name: Build with all supported GHC
-      run: nix build .#pyf_all
+    - name: Build with GHC ${{ matrix.ghc }}
+      run: nix build .#pyf_${{ matrix.ghc }}
 
   stack_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,8 +31,10 @@ jobs:
       run: sudo apt-get install haskell-stack
 
     # Build stack
+    - name: Stack 9.8
+      run: stack --resolver nightly-2024-05-15 test
     - name: Stack 9.6
-      run: stack --resolver nightly-2023-10-24 test
+      run: stack --resolver lts-22.22 test
     - name: Stack 9.4
       run: stack --resolver lts-21.17 test
     - name: Stack 9.2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,27 +28,23 @@ jobs:
       run: nix build .#pyf_${{ matrix.ghc }}
 
   stack_build:
+    strategy:
+      matrix:
+        resolver: [ lts-14.27 # 8.6
+                  , lts-16.31 # 8.8
+                  , lts-17.1 # 8.10
+                  , lts-19.1 # 9.0
+                  , lts-20.26 # 9.2
+                  , lts-21.17 # 9.4
+                  , lts-22.22 # 9.6
+                  , nightly-2024-05-15 # 9.8 nightly
+                  ]
+
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
     - name: Setup Stack
       run: sudo apt-get install haskell-stack
-
-    # Build stack
-    - name: Stack 9.8
-      run: stack --resolver nightly-2024-05-15 test
-    - name: Stack 9.6
-      run: stack --resolver lts-22.22 test
-    - name: Stack 9.4
-      run: stack --resolver lts-21.17 test
-    - name: Stack 9.2
-      run: stack --resolver lts-20.26 test
-    - name: Stack 9.0
-      run: stack --resolver lts-19.1 test
-    - name: Stack 8.10
-      run: stack --resolver lts-17.1 test
-    - name: Stack 8.8
-      run: stack --resolver lts-16.31 test
-    - name: Stack 8.6
-      run: stack --resolver lts-14.27 test
+    - name: Stack resolver ${{ matrix.resolver }}
+      run: stack --resolver ${{ matrix.resolver }} test

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -20,15 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1698226488,
-        "narHash": "sha256-DdmQFlDZfRnXkW1VRa3J5bzmDgtRWZ9NU44fN66CbIA=",
+        "lastModified": 1715759831,
+        "narHash": "sha256-IqSVO1C30USnIVzDoRZdBNC7uYPuRbxBeaty32CU4p8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "be5c30bf2c89ccfd6e2d8ebba54c25d7c0c80764",
+        "rev": "54b7ab5b45c62a29e1c5a6dab12df27d857ce3d1",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/src/PyF/Internal/Meta.hs
+++ b/src/PyF/Internal/Meta.hs
@@ -161,7 +161,7 @@ toExp _ Expr.HsIPVar {} = noTH "toExp" "HsIPVar"
 toExp _ (Expr.HsLit _ l) = TH.LitE (toLit l)
 toExp _ (Expr.HsOverLit _ OverLit {ol_val}) = TH.LitE (toLit' ol_val)
 toExp d (Expr.HsApp _ e1 e2) = TH.AppE (toExp d . unLoc $ e1) (toExp d . unLoc $ e2)
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc(9,10,0)
 toExp d (Expr.HsAppType _ e HsWC{hswc_body}) = TH.AppTypeE (toExp d . unLoc $ e) (toType . unLoc $ hswc_body)
 toExp d (Expr.ExprWithTySig _ e HsWC{hswc_body=unLoc -> HsSig{sig_body}}) = TH.SigE (toExp d . unLoc $ e) (toType . unLoc $ sig_body)
 #elif MIN_VERSION_ghc(9,6,0)
@@ -180,7 +180,7 @@ toExp d (Expr.ExprWithTySig HsWC{hswc_body=HsIB{hsib_body}} e) = TH.SigE (toExp 
 toExp d (Expr.OpApp _ e1 o e2) = TH.UInfixE (toExp d . unLoc $ e1) (toExp d . unLoc $ o) (toExp d . unLoc $ e2)
 toExp d (Expr.NegApp _ e _) = TH.AppE (TH.VarE 'negate) (toExp d . unLoc $ e)
 -- NOTE: for lambda, there is only one match
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc(9,10,0)
 toExp d (Expr.HsLam _ _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)])))) = TH.LamE (fmap (toPat d) ps) (toExp d e)
 #elif MIN_VERSION_ghc(9,6,0)
 toExp d (Expr.HsLam _ (Expr.MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (Expr.GRHSs _ [unLoc -> Expr.GRHS _ _ (unLoc -> e)] _)])))) = TH.LamE (fmap (toPat d) ps) (toExp d e)
@@ -218,7 +218,7 @@ toExp d (Expr.ExplicitTuple _ (map unLoc -> args) boxity) = ctor tupArgs
 {- ORMOLU_ENABLE -}
 
 -- toExp (Expr.List _ xs)                        = TH.ListE (fmap toExp xs)
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc(9,10,0)
 toExp d (Expr.HsPar _ e) = TH.ParensE (toExp d . unLoc $ e)
 #elif MIN_VERSION_ghc(9,3,0)
 toExp d (Expr.HsPar _ _ e _) = TH.ParensE (toExp d . unLoc $ e)

--- a/src/PyF/Internal/QQ.hs
+++ b/src/PyF/Internal/QQ.hs
@@ -198,7 +198,7 @@ findFreeVariables item = allNames
       Just (HsVar _ l) -> [l]
 #endif
 
-#if MIN_VERSION_ghc(9,8,0)
+#if MIN_VERSION_ghc(9,10,0)
       Just (HsLam _ _ (MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (GRHSs _ [unLoc -> GRHS _ _ (unLoc -> e)] _)])))) -> filter keepVar subVars
 #elif MIN_VERSION_ghc(9,6,0)
       Just (HsLam _ (MG _ (unLoc -> (map unLoc -> [Expr.Match _ _ (map unLoc -> ps) (GRHSs _ [unLoc -> GRHS _ _ (unLoc -> e)] _)])))) -> filter keepVar subVars


### PR DESCRIPTION
- New stack builder for 9.8
- nixpkgs bump
- Disabled the "buildFromSdist". I don't remember why this was there and looks like it adds some dependencies to the build.
- Removed nix ghc 8.8 support, not in nixpkgs anymore. This is still tested by stack.
- Added builder `pyf_910`, works when using `nix develop .#pyf_910`, but build is broken.
- Fixed the CPP code for GHC 9.8. I wrongly tested for GHC 9.8 instead of GHC 9.10 in previous support commit for 9.10, resulting in broken 9.8. This is fixed and 9.8 was tested again.