### PR TITLE
fix: correctly remove indentation one line even if escaped line brake

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 # Revision history for PyF
 
-- Support for GHC 9.12
+- Fix indentation in `fmtTrim` when line break was escaped (bug https://github.com/guibou/PyF/issues/141).
+- Support for GHC 9.12.
+- Fix for tests in GHC 9.10.
 - No more "python" reference check in the test phase. I'm removing complexity,
   and if it does not match the python implementation, we can just introduce a
   new test case. Note that python checking can be reimplemented easilly by

--- a/src/PyF.hs
+++ b/src/PyF.hs
@@ -38,7 +38,9 @@ fmt = mkFormatter "fmt" fmtConfig
 
 -- | Format with whitespace trimming.
 fmtTrim :: QuasiQuoter
-fmtTrim = mkFormatter "fmtTrim" (addTrim fmtConfig)
+fmtTrim = let
+  qq = mkFormatter "fmtTrim" fmtConfig
+  in qq { quoteExp = \s -> quoteExp qq (trimIndent  s) }
 
 -- | Multiline string, no interpolation.
 str :: QuasiQuoter
@@ -46,7 +48,8 @@ str = mkFormatter "str" strConfig
 
 -- | Multiline string, no interpolation, but does indentation trimming.
 strTrim :: QuasiQuoter
-strTrim = mkFormatter "strTrim" (addTrim strConfig)
+strTrim = let qq = mkFormatter "strTrim" strConfig
+  in qq { quoteExp = \s -> quoteExp qq (trimIndent  s) }
 
 -- | Raw string, neither interpolation nor escaping is performed.
 raw :: QuasiQuoter

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -482,18 +482,18 @@ yeah\
                   hello
                   - a
                    - {
-                2 + 2
+                      2 + 2
                    :d}|]
         `shouldBe` "hello\n- a\n - 4"
 
-    it "behaves well with escaped first line" $ do
-      [fmtTrim|\
-                  - a
-                  - b
-                  |]
-        `shouldBe` "- a\n- b\n"
     it "Do not touch single lines" $ do
       [fmtTrim|  hello|] `shouldBe` "  hello"
+    it "trim when there is a linebreak" $ do
+      -- https://github.com/guibou/PyF/issues/141
+      [fmtTrim|
+          Cannot convert formula 2.0 * exponent(unit=s, value=1.0) which has unit dimensionless to\
+           unit dimensionless for they have different dimensions|]
+          `shouldBe` "Cannot convert formula 2.0 * exponent(unit=s, value=1.0) which has unit dimensionless to unit dimensionless for they have different dimensions"
   describe "raw" $ do
     it "does not escape anything" $
       [raw|hello


### PR DESCRIPTION
Close #141.

```
[fmtTrim|
   foo\
   bar
|]
```

should be `foobar` instead of `foo   bar`.

This is fixed by doing the whitespace trimming on the input string of
the quasiquotes (here `\n    foo\    bar`) instead of the output string.

However it breaks two previous features:

- When an interpolation block had whitespace, it should now be indented at least as much as the string, otherwise the interpolation block indentation will be used as reference.
- Escaping the first line is now ignored. But actually, escaping the first line behaves exactly as not escaping the first line, so it breaks nothing.